### PR TITLE
fix(ci): support optional PAT for release-please PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
       # Update versions.json when a release is created
       - uses: actions/checkout@v4


### PR DESCRIPTION
The default GITHUB_TOKEN cannot create pull requests unless the
repository setting "Allow GitHub Actions to create and approve pull
requests" is enabled (Settings > Actions > General > Workflow
permissions). Add support for an optional RELEASE_PLEASE_TOKEN secret
that falls back to the default github.token.

https://claude.ai/code/session_01B4b3vqMGtYpe6hgasmxUTN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication mechanism for automated release workflows to improve reliability and security of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->