### PR TITLE
docs: update print-styles component list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Frontmatter-driven document management with Zod-validated schemas:
 - **Classification taxonomy** — Public, Internal, Confidential, Restricted — with color-coded banners in reading view
 - **Watermark levels** — Five presets (off → screaming) for draft documents
 - **Schema validation** — Auto-validate frontmatter on save with smart warnings (e.g., "draft without watermark", "confidential without reviewers")
-- **Specialized schemas** — ADR, threat model, runbook, and slides templates with required field validation
+- **Specialized schemas** — ADR, threat model, runbook, and slides — with required field validation
+- **Document templates** — ADR, threat model, one-pager, and tech-talk slides
 - **Table of contents** — Generate GitHub-compatible TOC from headings, inserted after frontmatter
 - **CSS class derivation** — Apply `cssclass` values from frontmatter for PDF export styling
 
@@ -35,9 +36,7 @@ Frontmatter-driven document management with Zod-validated schemas:
 
 CSS snippets for Obsidian's PDF export (`@yaae/print-styles`):
 
-- Classification banners and watermarks
-- Typography presets
-- TOC, links, code blocks, page breaks, page numbers, and image handling
+Classification banners and watermarks, typography presets, TOC, links, code blocks, tables, page breaks, page numbers, landscape mode, signature blocks, copy-safe text, images, and appearance tuning
 
 ## Installation
 


### PR DESCRIPTION
Updates the print-styles component list to include all 11 CSS components.

### Changes
- Expanded the print-styles description from 6 to 11 components
- Added: tables, landscape mode, signature blocks, copy-safe text, and appearance tuning
- Changed from bullet list to flowing paragraph for better readability

Fixes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clarified descriptions of available document templates (ADR, threat model, one-pager, tech-talk slides) and expanded print styling features including tables, landscape mode, signature blocks, and appearance customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->