### PR TITLE
feat(theming): layered light/dark variables, extensibility, plus 36 fixes from 8-agent bug hunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ test-vault/.obsidian/plugins/yaae/data.json
 
 # Test vault PDFs (generated during smoke testing)
 test-vault/*.pdf
+
+# Beads runtime artifacts (issue tracker internals)
+.beads/backup/
+.beads/embeddeddolt/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ An Obsidian plugin for writers who care about prose. Combines iA Writer-style pr
 
 Color-code your writing by part of speech — adjectives, nouns, adverbs, verbs, and conjunctions — to see the structure of your prose at a glance. Inspired by [iA Writer's syntax highlighting](https://ia.net/writer).
 
-- Per-category color customization
-- Custom word lists
+- Themable per-category colors via CSS variables (`--yaae-pos-*-color-{light,dark}`) — see [docs/theming.md](docs/theming.md)
+- Custom word lists with their own colors
 - Works in both Editor/Live Preview and Reading View
 - Automatically hidden in PDF export
 - Excludes code blocks, frontmatter, and table headers

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,103 @@
+# Theming YAAE
+
+YAAE exposes its visual tunables as CSS custom properties. Theme authors and
+snippet writers can override any of them without fighting plugin specificity.
+
+## How to override
+
+Three ways, in order of precedence:
+
+1. **Theme CSS** — `body.theme-dark { --yaae-pos-noun-color-dark: #ff8866; }` in
+   your theme file. Higher specificity than the plugin's defaults; cleanest path.
+2. **CSS snippet** — same as above, dropped into `.obsidian/snippets/yours.css`.
+3. **Style Settings plugin** — install it; YAAE registers all knobs via the
+   `@settings` block in `styles.css`. Pick colors and sizes through Obsidian UI.
+
+The plugin itself does not edit the unsuffixed variable names below at runtime
+(except a one-shot migration for users who customized POS colors before the
+light/dark refactor). That means your `body.theme-dark` overrides win.
+
+## Variable layering
+
+Each themable color uses a layered pattern:
+
+```css
+body { --yaae-pos-noun-color: var(--yaae-pos-noun-color-light, #ce4924); }
+body.theme-dark { --yaae-pos-noun-color: var(--yaae-pos-noun-color-dark, #e87a5f); }
+```
+
+- `--yaae-pos-noun-color` — the **public** name feature CSS reads. Don't
+  override this directly unless you want to force the same color across light
+  and dark themes.
+- `--yaae-pos-noun-color-light` / `-dark` — the **knobs**. Override these to
+  recolor per-theme.
+
+## Editor — Prose Highlighting
+
+Five POS categories. Defaults inspired by iA Writer for light, brighter
+desaturated equivalents for dark.
+
+| Variable                                | Default (light) | Default (dark) |
+| --------------------------------------- | --------------- | -------------- |
+| `--yaae-pos-adjective-color-{light,dark}`  | `#b97a0a`      | `#f0b150`      |
+| `--yaae-pos-noun-color-{light,dark}`       | `#ce4924`      | `#e87a5f`      |
+| `--yaae-pos-adverb-color-{light,dark}`     | `#c333a7`      | `#e07cc8`      |
+| `--yaae-pos-verb-color-{light,dark}`       | `#177eb8`      | `#5cb0e8`      |
+| `--yaae-pos-conjunction-color-{light,dark}`| `#01934e`      | `#4cc887`      |
+
+## Editor — Focus Mode
+
+| Variable                            | Default                |
+| ----------------------------------- | ---------------------- |
+| `--yaae-dimmed-color-{light,dark}`  | `var(--text-faint)`    |
+| `--yaae-dimmed-transition`          | `0.15s`                |
+
+The dimmed color falls through to Obsidian's `--text-faint`, which themes
+already paint correctly per mode. Override only if you want a non-faint hue.
+
+## Editor — Syntax Dimming and Headings
+
+| Variable                                  | Default |
+| ----------------------------------------- | ------- |
+| `--yaae-syntax-dimming-opacity`           | `0.3`   |
+| `--yaae-syntax-dimming-active-opacity`    | `0.7`   |
+| `--yaae-gutter-width`                     | `4.5rem`|
+
+These don't have light/dark variants — they're scalar tunables, not colors.
+
+## Reading View — Classification Banner
+
+Banner colors come from the active classification's `color`/`background`
+(plus optional `colorDark`/`backgroundDark`) and flow through inline custom
+properties on the banner element:
+
+```css
+.yaae-classification-banner {
+  background: var(--yaae-banner-bg);
+  color: var(--yaae-banner-color);
+  border: 1px solid var(--yaae-banner-color);
+}
+
+body.theme-dark .yaae-classification-banner {
+  background: var(--yaae-banner-bg-dark, var(--yaae-banner-bg));
+  color: var(--yaae-banner-color-dark, var(--yaae-banner-color));
+  border-color: var(--yaae-banner-color-dark, var(--yaae-banner-color));
+}
+```
+
+Theme authors can override the banner styles entirely by targeting
+`.yaae-classification-banner` (and its `body.theme-dark` variant).
+
+## PDF Print Styles
+
+Print styles live in `packages/print-styles/` and are bundled into Obsidian's
+PDF export pipeline. They expose ~30 tunables under the `PDF Print Styles`
+heading in the Style Settings plugin (`code`, `links`, `page-numbers`, `tables`,
+`toc`, `header-footer`, `dark`, `banner`, `typography` sub-sections).
+
+PDF dark mode uses three classes — `pdf-theme-light`, `pdf-theme-dark`,
+`pdf-theme-auto` — set by document frontmatter `export.pdf.theme`. The
+`pdf-theme-auto` class respects `@media (prefers-color-scheme: dark)` at print
+time. `@page` margin boxes (classification banner, page numbers) cannot read
+CSS custom properties, so banner colors are baked in at generation time based
+on the active theme.

--- a/main.ts
+++ b/main.ts
@@ -393,6 +393,7 @@ export default class YaaePlugin extends Plugin {
   async validateCurrentFile() {
     const file = this.app.workspace.getActiveFile();
     if (!file) return;
+    if (!(file instanceof TFile)) return;
     const content = await this.app.vault.read(file);
     const result = validateMarkdown(content);
 
@@ -423,6 +424,7 @@ export default class YaaePlugin extends Plugin {
   async generateTocForCurrentFile() {
     const file = this.app.workspace.getActiveFile();
     if (!file) return;
+    if (!(file instanceof TFile)) return;
     const content = await this.app.vault.read(file);
 
     // Race guard: if the user switched files during the read, do NOT modify
@@ -445,6 +447,7 @@ export default class YaaePlugin extends Plugin {
   async applyCssClassesFromFrontmatter() {
     const file = this.app.workspace.getActiveFile();
     if (!file) return;
+    if (!(file instanceof TFile)) return;
     const content = await this.app.vault.read(file);
     const result = validateMarkdown(content);
 

--- a/main.ts
+++ b/main.ts
@@ -138,9 +138,10 @@ export default class YaaePlugin extends Plugin {
     this.addCommand({
       id: 'yaae-generate-toc',
       name: 'Generate table of contents',
-      editorCheckCallback: (checking, editor) => {
-        if (checking) return true;
-        this.generateTocForCurrentFile();
+      editorCheckCallback: (checking, _editor) => {
+        const file = this.app.workspace.getActiveFile();
+        if (!file || file.extension !== 'md') return false;
+        if (!checking) this.generateTocForCurrentFile();
         return true;
       },
     });

--- a/main.ts
+++ b/main.ts
@@ -56,8 +56,14 @@ export default class YaaePlugin extends Plugin {
 
     // --- Prose Highlight ---
 
-    // Dynamic CSS for POS and custom list colors
+    // Dynamic CSS for POS and custom list colors. init() may flip the
+    // posColorsMigrated latch on first run after upgrading from a pre-
+    // light/dark schema; persist that so subsequent reloads skip migration.
+    const wasMigrated = this.settings.proseHighlight.posColorsMigrated === true;
     this.styleManager.init(this.settings.proseHighlight);
+    if (!wasMigrated && this.settings.proseHighlight.posColorsMigrated) {
+      await this.saveSettings();
+    }
 
     // Compile word lists from saved settings
     this.wordListMatcher.compile(

--- a/main.ts
+++ b/main.ts
@@ -582,7 +582,10 @@ class YaaeSettingTab extends PluginSettingTab {
         text: tab.label,
         cls: `yaae-settings-tab${this.activeTab === tab.id ? ' is-active' : ''}`,
       });
-      btn.addEventListener('click', () => {
+      // Use registerDomEvent (inherited from Component via PluginSettingTab)
+      // so listeners are auto-removed when the tab is unloaded — raw
+      // addEventListener leaks one listener per display() rebuild.
+      this.registerDomEvent(btn, 'click', () => {
         this.activeTab = tab.id;
         this.display();
       });

--- a/main.ts
+++ b/main.ts
@@ -467,13 +467,19 @@ export default class YaaePlugin extends Plugin {
     const classes = deriveCssClasses(result.data);
 
     await this.app.fileManager.processFrontMatter(file, (fm) => {
-      // Merge: keep user-defined classes, replace only pdf-* classes
-      const existing: string[] = Array.isArray(fm.cssclasses)
+      // Merge: keep user-defined classes, replace only pdf-* classes.
+      // Defensive: cssclasses may be a single string, array, or array with
+      // non-string entries (e.g., numbers from a hand-edited YAML doc) —
+      // filter to strings before calling startsWith() so we don't TypeError
+      // inside processFrontMatter.
+      const existing: unknown[] = Array.isArray(fm.cssclasses)
         ? fm.cssclasses
         : typeof fm.cssclasses === 'string'
           ? [fm.cssclasses]
           : [];
-      const userClasses = existing.filter((c: string) => !c.startsWith('pdf-'));
+      const userClasses = existing.filter(
+        (c): c is string => typeof c === 'string' && !c.startsWith('pdf-'),
+      );
       fm.cssclasses = [...userClasses, ...classes];
     });
 

--- a/main.ts
+++ b/main.ts
@@ -464,6 +464,7 @@ export default class YaaePlugin extends Plugin {
       signatureBlock: false,
       bannerPosition: doc.bannerPosition,
       showClassificationBanner: doc.showClassificationBanner,
+      theme: doc.theme,
     };
   }
 

--- a/main.ts
+++ b/main.ts
@@ -415,6 +415,14 @@ export default class YaaePlugin extends Plugin {
     if (!file) return;
     const content = await this.app.vault.read(file);
 
+    // Race guard: if the user switched files during the read, do NOT modify
+    // the file we started with — that would write a TOC for the previous
+    // document into the now-active one. Bail with a debug message.
+    if (this.app.workspace.getActiveFile() !== file) {
+      console.debug('[yaae] TOC abort: active file changed mid-read');
+      return;
+    }
+
     // Get TOC depth from frontmatter or settings
     const fmResult = validateMarkdown(content);
     const depth = fmResult.data?.export?.pdf?.tocDepth ?? this.settings.document.tocDepth;
@@ -471,15 +479,27 @@ export default class YaaePlugin extends Plugin {
   /**
    * Read active document's frontmatter and update page chrome with its
    * classification + signature block + per-document theme override.
+   *
+   * Race-aware: if the active file changes during the async vault.read,
+   * we abort the update so the chrome doesn't reflect a stale file.
    */
   async updatePageChromeFromActiveFile(): Promise<void> {
-    const file = this.app.workspace.getActiveFile();
-    if (!file || file.extension !== 'md') {
+    const startFile = this.app.workspace.getActiveFile();
+    if (!startFile || startFile.extension !== 'md') {
       this.pageChromeManager.update(this.buildPageChromeState());
       return;
     }
 
-    const content = await this.app.vault.read(file);
+    const content = await this.app.vault.read(startFile);
+
+    // Race guard: if the user switched files during the read, the page chrome
+    // should reflect the *new* active file (or be left alone), not the file we
+    // started reading. Bail and let the next active-leaf-change re-trigger us.
+    if (this.app.workspace.getActiveFile() !== startFile) {
+      console.debug('[yaae] updatePageChromeFromActiveFile: active file changed mid-read, aborting');
+      return;
+    }
+
     const result = validateMarkdown(content);
 
     const classification = result.data?.classification ?? this.settings.document.defaultClassification;

--- a/main.ts
+++ b/main.ts
@@ -206,16 +206,17 @@ export default class YaaePlugin extends Plugin {
       createDefangedLinksProcessor(() => this.settings.document),
     );
 
-    // Validate on save
-    if (this.settings.document.validateOnSave) {
-      this.registerEvent(
-        this.app.vault.on('modify', (file) => {
-          if (file instanceof TFile && file.extension === 'md') {
-            this.validateFileQuietly(file);
-          }
-        }),
-      );
-    }
+    // Validate on save. Listener is always registered; gate the work on the
+    // *current* setting value so toggling validateOnSave in the UI takes
+    // effect without requiring a plugin reload.
+    this.registerEvent(
+      this.app.vault.on('modify', (file) => {
+        if (!this.settings.document.validateOnSave) return;
+        if (file instanceof TFile && file.extension === 'md') {
+          this.validateFileQuietly(file);
+        }
+      }),
+    );
 
     // Settings tab
     this.addSettingTab(new YaaeSettingTab(this.app, this));

--- a/main.ts
+++ b/main.ts
@@ -263,6 +263,14 @@ export default class YaaePlugin extends Plugin {
       this.settings.document,
     );
 
+    // Defensive: a corrupt or hand-edited data.json can land here with
+    // arrays set to null, strings, or other non-arrays (Object.assign
+    // shallow-merges and won't restore the default []). Reset critical
+    // arrays so downstream code can safely .map / .filter.
+    if (!Array.isArray(this.settings.document.customClassifications)) {
+      this.settings.document.customClassifications = [];
+    }
+
     // Migrate deprecated expandLinks/plainLinks booleans to links enum
     const doc = this.settings.document;
     if (doc.links === 'expand' && (doc.plainLinks || !doc.expandLinks)) {

--- a/main.ts
+++ b/main.ts
@@ -52,6 +52,7 @@ export default class YaaePlugin extends Plugin {
   private syntaxDimmingStatusEl: HTMLElement | null = null;
 
   async onload() {
+    console.debug('[yaae] onload: starting plugin initialization');
     await this.loadSettings();
 
     // --- Prose Highlight ---
@@ -237,9 +238,11 @@ export default class YaaePlugin extends Plugin {
 
     // Settings tab
     this.addSettingTab(new YaaeSettingTab(this.app, this));
+    console.debug('[yaae] onload: plugin initialization complete');
   }
 
   onunload() {
+    console.debug('[yaae] onunload: tearing down plugin');
     this.styleManager.destroy();
     this.dynamicPdfPrintStyles.destroy();
     this.pageChromeManager.destroy();
@@ -437,6 +440,8 @@ export default class YaaePlugin extends Plugin {
       console.warn(`[yaae] ${file.path}: validation errors`, result.errors?.issues);
     } else if (result.warnings.length > 0) {
       console.warn(`[yaae] ${file.path}: warnings`, result.warnings);
+    } else {
+      console.debug(`[yaae] ${file.path}: frontmatter valid`);
     }
   }
 
@@ -460,6 +465,7 @@ export default class YaaePlugin extends Plugin {
 
     const { content: updated, entryCount } = generateToc(content, depth);
     await this.app.vault.modify(file, updated);
+    console.info(`[yaae] Successfully generated TOC. File: ${file.path}, Entries: ${entryCount}, Depth: ${depth}`);
     new Notice(`Table of Contents generated with ${entryCount} entries`);
   }
 
@@ -494,6 +500,7 @@ export default class YaaePlugin extends Plugin {
       fm.cssclasses = [...userClasses, ...classes];
     });
 
+    console.info(`[yaae] Successfully applied CSS classes from frontmatter. File: ${file.path}, Classes: ${classes.join(', ')}`);
     new Notice(`Applied CSS classes: ${classes.join(', ')}`);
   }
 

--- a/main.ts
+++ b/main.ts
@@ -275,7 +275,6 @@ export default class YaaePlugin extends Plugin {
     // Migrate deprecated expandLinks/plainLinks booleans to links enum
     const doc = this.settings.document;
     if (doc.links === 'expand' && (doc.plainLinks || !doc.expandLinks)) {
-      const previousLinks = doc.links;
       if (doc.plainLinks) {
         doc.links = 'plain' as LinksMode;
       } else if (!doc.expandLinks) {
@@ -285,7 +284,16 @@ export default class YaaePlugin extends Plugin {
         `[yaae] Migrated deprecated link booleans to links enum. ` +
         `expandLinks: ${doc.expandLinks}, plainLinks: ${doc.plainLinks} → links: ${doc.links}`,
       );
-      await this.saveSettings();
+      // Defer the persist so loadSettings() resolves cleanly before any
+      // saveSettings() write — calling saveSettings() while loadSettings()
+      // is still on the stack creates a narrow window where a concurrent
+      // load could observe partial state. queueMicrotask runs after
+      // loadSettings returns but before the next paint.
+      queueMicrotask(() => {
+        this.saveSettings().catch((err) => {
+          console.warn('[yaae] Failed to persist link enum migration:', err);
+        });
+      });
     }
   }
 

--- a/main.ts
+++ b/main.ts
@@ -290,11 +290,7 @@ export default class YaaePlugin extends Plugin {
         `[yaae] Migrated deprecated link booleans to links enum. ` +
         `expandLinks: ${doc.expandLinks}, plainLinks: ${doc.plainLinks} → links: ${doc.links}`,
       );
-      // Defer the persist so loadSettings() resolves cleanly before any
-      // saveSettings() write — calling saveSettings() while loadSettings()
-      // is still on the stack creates a narrow window where a concurrent
-      // load could observe partial state. queueMicrotask runs after
-      // loadSettings returns but before the next paint.
+      // Persist after loadSettings resolves — don't await inside the loader.
       queueMicrotask(() => {
         this.saveSettings().catch((err) => {
           console.warn('[yaae] Failed to persist link enum migration:', err);

--- a/main.ts
+++ b/main.ts
@@ -467,7 +467,10 @@ export default class YaaePlugin extends Plugin {
     };
   }
 
-  /** Read active document's frontmatter and update page chrome with its classification. */
+  /**
+   * Read active document's frontmatter and update page chrome with its
+   * classification + signature block + per-document theme override.
+   */
   async updatePageChromeFromActiveFile(): Promise<void> {
     const file = this.app.workspace.getActiveFile();
     if (!file || file.extension !== 'md') {
@@ -480,10 +483,12 @@ export default class YaaePlugin extends Plugin {
 
     const classification = result.data?.classification ?? this.settings.document.defaultClassification;
     const signatureBlock = result.data?.export?.pdf?.signatureBlock ?? false;
+    const theme = result.data?.export?.pdf?.theme;
 
     this.pageChromeManager.update({
       ...this.buildPageChromeState(classification),
       signatureBlock,
+      ...(theme ? { theme } : {}),
     });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -191,6 +191,16 @@ export default class YaaePlugin extends Plugin {
       }),
     );
 
+    // Bootstrap from the currently-active file. active-leaf-change does not
+    // fire for the leaf already open at startup, so without this the page
+    // chrome would reflect default classification instead of the open
+    // document's frontmatter.
+    this.app.workspace.onLayoutReady(() => {
+      this.updatePageChromeFromActiveFile().catch((err) => {
+        console.warn('[yaae] Failed to bootstrap page chrome from active file:', err);
+      });
+    });
+
     // Classification banner in reading view (always registered; checks setting at runtime)
     this.registerMarkdownPostProcessor(
       createClassificationBannerProcessor(() => this.settings.document),
@@ -482,11 +492,22 @@ export default class YaaePlugin extends Plugin {
    *
    * Race-aware: if the active file changes during the async vault.read,
    * we abort the update so the chrome doesn't reflect a stale file.
+   *
+   * Non-markdown active leaves (PDF, canvas, image preview) leave the
+   * chrome untouched so the last markdown classification is preserved
+   * for export.
    */
   async updatePageChromeFromActiveFile(): Promise<void> {
     const startFile = this.app.workspace.getActiveFile();
-    if (!startFile || startFile.extension !== 'md') {
+    if (!startFile) {
+      // No active file at all — fall back to defaults so chrome reflects settings.
       this.pageChromeManager.update(this.buildPageChromeState());
+      return;
+    }
+    if (startFile.extension !== 'md') {
+      // Active leaf is non-markdown (e.g., embedded PDF, canvas). Leave the
+      // existing page chrome alone so the last markdown file's classification
+      // is preserved for export.
       return;
     }
 

--- a/src/document/classification-banner.ts
+++ b/src/document/classification-banner.ts
@@ -3,6 +3,7 @@ import {
   getClassificationMeta,
   type CustomClassification,
 } from '../schemas';
+import { sanitizeCssId } from './css-sanitize';
 import type { DocumentSettings } from './settings';
 
 /**
@@ -32,26 +33,33 @@ export function createClassificationBannerProcessor(
     const meta = getClassificationMeta(classification, settings.customClassifications);
     if (!meta) return;
 
+    // The class-name fragment must be a safe CSS identifier. Use the
+    // resolved `meta.level` (already trimmed inside getClassificationMeta)
+    // so the banner class matches the looked-up classification, then
+    // sanitize to drop spaces or selector-injection characters.
+    const classFragment = sanitizeCssId(meta.level);
     const banner = document.createElement('div');
-    banner.className = `yaae-classification-banner yaae-${classification}`;
+    banner.className = classFragment
+      ? `yaae-classification-banner yaae-${classFragment}`
+      : 'yaae-classification-banner';
     banner.textContent = meta.label;
 
     // Color/background flow through CSS custom properties so styles.css
     // can switch light↔dark via `body.theme-dark .yaae-classification-banner`.
-    // Layout is set via inline style for self-containment in reading view.
+    // Layout is set via setProperty() for each declaration; using
+    // `cssText += ...` here clobbers previously-set custom properties in
+    // some Chromium builds, leaving the banner unstyled.
     banner.style.setProperty('--yaae-banner-color', meta.color);
     banner.style.setProperty('--yaae-banner-bg', meta.background);
     if (meta.colorDark) banner.style.setProperty('--yaae-banner-color-dark', meta.colorDark);
     if (meta.backgroundDark) banner.style.setProperty('--yaae-banner-bg-dark', meta.backgroundDark);
-    banner.style.cssText += [
-      'text-align: center',
-      'font-size: 11px',
-      'font-weight: 700',
-      'letter-spacing: 0.1em',
-      'padding: 3px 8px',
-      'margin-bottom: 8px',
-      'border-radius: 3px',
-    ].join(';');
+    banner.style.setProperty('text-align', 'center');
+    banner.style.setProperty('font-size', '11px');
+    banner.style.setProperty('font-weight', '700');
+    banner.style.setProperty('letter-spacing', '0.1em');
+    banner.style.setProperty('padding', '3px 8px');
+    banner.style.setProperty('margin-bottom', '8px');
+    banner.style.setProperty('border-radius', '3px');
 
     el.insertBefore(banner, el.firstChild);
   };

--- a/src/document/classification-banner.ts
+++ b/src/document/classification-banner.ts
@@ -35,10 +35,15 @@ export function createClassificationBannerProcessor(
     const banner = document.createElement('div');
     banner.className = `yaae-classification-banner yaae-${classification}`;
     banner.textContent = meta.label;
-    banner.style.cssText = [
-      `background: ${meta.background}`,
-      `color: ${meta.color}`,
-      `border: 1px solid ${meta.color}`,
+
+    // Color/background flow through CSS custom properties so styles.css
+    // can switch light↔dark via `body.theme-dark .yaae-classification-banner`.
+    // Layout is set via inline style for self-containment in reading view.
+    banner.style.setProperty('--yaae-banner-color', meta.color);
+    banner.style.setProperty('--yaae-banner-bg', meta.background);
+    if (meta.colorDark) banner.style.setProperty('--yaae-banner-color-dark', meta.colorDark);
+    if (meta.backgroundDark) banner.style.setProperty('--yaae-banner-bg-dark', meta.backgroundDark);
+    banner.style.cssText += [
       'text-align: center',
       'font-size: 11px',
       'font-weight: 700',

--- a/src/document/css-sanitize.ts
+++ b/src/document/css-sanitize.ts
@@ -15,10 +15,17 @@ export function escapeCssString(value: string): string {
     .replace(/\r/g, '');
 }
 
-/** Validate a hex color value. Returns fallback if the value isn't a valid hex color. */
+/**
+ * Validate a hex color value. Returns the fallback if the value isn't a
+ * valid hex color, and logs a warning so a corrupt classification color
+ * doesn't silently render as black-on-white (visually indistinguishable
+ * from PUBLIC) and mask the misclassification.
+ */
 const HEX_COLOR = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 export function sanitizeColor(value: string, fallback: string): string {
-  return HEX_COLOR.test(value) ? value : fallback;
+  if (HEX_COLOR.test(value)) return value;
+  console.warn('[yaae] invalid color input rejected:', value);
+  return fallback;
 }
 
 /** Coerce to number and clamp within a range. Returns fallback for non-finite values. */

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -178,8 +178,13 @@ export class PageChromeManager {
     // by Chromium's print engine, so nesting is required for the dark
     // override to take effect during PDF export. Only banner colors swap;
     // headers/footers/page numbers stay neutral.
+    //
+    // Always emit the override block when theme is 'auto', even if no
+    // explicit dark colors are defined — fall back to the light values.
+    // This way 'auto' never silently degrades to 'light' for custom
+    // classifications that haven't filled in their dark variants yet.
     let autoOverride = '';
-    if (state.theme === 'auto' && meta && (meta.colorDark || meta.backgroundDark)) {
+    if (state.theme === 'auto' && meta) {
       const altColor = sanitizeColor(meta.colorDark ?? meta.color, '#000');
       const altBg = sanitizeColor(meta.backgroundDark ?? meta.background, '#fff');
       const altBoxes: string[] = [];

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -32,6 +32,8 @@ export interface PageChromeState {
   signatureBlock: boolean;
   bannerPosition: 'top' | 'both';
   showClassificationBanner: boolean;
+  /** Theme mode — picks light/dark colors for classification banners. */
+  theme: 'light' | 'dark' | 'auto';
 }
 
 /** Shared base styles for banner margin boxes.
@@ -104,10 +106,16 @@ export class PageChromeManager {
     const marginBoxes: string[] = [];
 
     // --- Classification banners ---
+    // @page margin boxes do not support var(), so colors are baked in statically.
+    // For 'dark' theme, use colorDark/backgroundDark (with light fallback).
+    // For 'auto', emit base (light) here; an @media override is appended below.
+    const useDarkBase = state.theme === 'dark';
     if (meta) {
       const label = escapeCssString(meta.label);
-      const color = sanitizeColor(meta.color, '#000');
-      const bg = sanitizeColor(meta.background, '#fff');
+      const baseColor = useDarkBase ? (meta.colorDark ?? meta.color) : meta.color;
+      const baseBg = useDarkBase ? (meta.backgroundDark ?? meta.background) : meta.background;
+      const color = sanitizeColor(baseColor, '#000');
+      const bg = sanitizeColor(baseBg, '#fff');
 
       if (hasTopBanner) {
         marginBoxes.push(`    @top-center {
@@ -164,12 +172,45 @@ export class PageChromeManager {
     }`);
     }
 
-    const css = `@media print {
+    let css = `@media print {
   @page {
     margin: 1in !important;
 ${marginBoxes.join('\n')}
   }
 }`;
+
+    // 'auto' theme — append an @media override that swaps banner colors to
+    // their dark variants when the print engine resolves prefers-color-scheme.
+    // Only banner colors swap; headers/footers/page numbers stay neutral.
+    if (state.theme === 'auto' && meta && (meta.colorDark || meta.backgroundDark)) {
+      const altColor = sanitizeColor(meta.colorDark ?? meta.color, '#000');
+      const altBg = sanitizeColor(meta.backgroundDark ?? meta.background, '#fff');
+      const altBoxes: string[] = [];
+      const altLabel = escapeCssString(meta.label);
+      if (hasTopBanner) {
+        altBoxes.push(`    @top-center {
+      content: "${altLabel}";
+      color: ${altColor};
+      background: ${altBg};
+      border-bottom: 2px solid ${altColor};${BANNER_BASE}
+    }`);
+      }
+      if (hasBottomBanner) {
+        altBoxes.push(`    @bottom-center {
+      content: "${altLabel}";
+      color: ${altColor};
+      background: ${altBg};
+      border-top: 2px solid ${altColor};${BANNER_BASE}
+    }`);
+      }
+      if (altBoxes.length > 0) {
+        css += `\n@media print and (prefers-color-scheme: dark) {
+  @page {
+${altBoxes.join('\n')}
+  }
+}`;
+      }
+    }
 
     this.styleEl.textContent = css;
     console.debug('[yaae] PageChromeManager updated. CSS:', css);

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -71,6 +71,11 @@ export class PageChromeManager {
   private styleEl: HTMLStyleElement | null = null;
 
   init(state: PageChromeState): void {
+    // Idempotent re-init: destroy any prior <style> first so a partial
+    // init failure or hot reload cannot leave orphaned elements in <head>.
+    if (this.styleEl) {
+      this.destroy();
+    }
     this.styleEl = document.createElement('style');
     this.styleEl.id = PAGE_CHROME_STYLE_ID;
     document.head.appendChild(this.styleEl);
@@ -286,6 +291,11 @@ export class DynamicPdfPrintStyleManager {
   private styleEl: HTMLStyleElement | null = null;
 
   init(settings: DocumentSettings): void {
+    // Idempotent re-init: destroy any prior <style> first so a partial
+    // init failure or hot reload cannot leave orphaned elements in <head>.
+    if (this.styleEl) {
+      this.destroy();
+    }
     this.styleEl = document.createElement('style');
     this.styleEl.id = DYNAMIC_PDF_STYLE_ID;
     document.head.appendChild(this.styleEl);

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -1,6 +1,6 @@
 import type { CustomClassification } from '../schemas/classification';
 import { getClassificationMeta } from '../schemas/classification';
-import type { DocumentSettings, FontPreset } from './settings';
+import type { DocumentSettings, FontPreset, ThemeMode } from './settings';
 import { DEFAULT_DOCUMENT_SETTINGS } from './settings';
 import { escapeCssString, sanitizeColor, clampNumber, sanitizeFontFamily, sanitizeCssId } from './css-sanitize';
 
@@ -38,7 +38,7 @@ export interface PageChromeState {
    * overrides propagate here from `YaaePlugin.updatePageChromeFromActiveFile`;
    * absent that, the global setting from `buildPageChromeState` is used.
    */
-  theme: 'light' | 'dark' | 'auto';
+  theme: ThemeMode;
 }
 
 /** Shared base styles for banner margin boxes.

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -32,6 +32,15 @@ export interface PageChromeState {
   signatureBlock: boolean;
   bannerPosition: 'top' | 'both';
   showClassificationBanner: boolean;
+  /**
+   * PDF theme override. Currently unused by the @page CSS itself
+   * (theme is applied via cssclasses on the document body), but tracked
+   * here so per-document `export.pdf.theme` frontmatter overrides
+   * propagate from {@link YaaePlugin.updatePageChromeFromActiveFile}
+   * and don't get silently dropped. Future work may consume this in
+   * margin-box styling.
+   */
+  theme?: 'light' | 'dark' | 'auto';
 }
 
 /** Shared base styles for banner margin boxes.

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -240,6 +240,7 @@ ${marginBoxes.join('\n')}
     if (this.styleEl) {
       this.styleEl.remove();
       this.styleEl = null;
+      console.debug('[yaae] PageChromeManager destroyed.');
     }
   }
 }
@@ -374,6 +375,7 @@ export class DynamicPdfPrintStyleManager {
     if (this.styleEl) {
       this.styleEl.remove();
       this.styleEl = null;
+      console.debug('[yaae] DynamicPdfPrintStyleManager destroyed.');
     }
   }
 }

--- a/src/document/print-styles.ts
+++ b/src/document/print-styles.ts
@@ -172,45 +172,50 @@ export class PageChromeManager {
     }`);
     }
 
-    let css = `@media print {
-  @page {
-    margin: 1in !important;
-${marginBoxes.join('\n')}
-  }
-}`;
-
-    // 'auto' theme — append an @media override that swaps banner colors to
-    // their dark variants when the print engine resolves prefers-color-scheme.
-    // Only banner colors swap; headers/footers/page numbers stay neutral.
+    // 'auto' theme — emit a *nested* `@media (prefers-color-scheme: dark)`
+    // inside the outer `@media print` block. The combined form
+    // `@media print and (prefers-color-scheme: dark)` is silently ignored
+    // by Chromium's print engine, so nesting is required for the dark
+    // override to take effect during PDF export. Only banner colors swap;
+    // headers/footers/page numbers stay neutral.
+    let autoOverride = '';
     if (state.theme === 'auto' && meta && (meta.colorDark || meta.backgroundDark)) {
       const altColor = sanitizeColor(meta.colorDark ?? meta.color, '#000');
       const altBg = sanitizeColor(meta.backgroundDark ?? meta.background, '#fff');
       const altBoxes: string[] = [];
       const altLabel = escapeCssString(meta.label);
       if (hasTopBanner) {
-        altBoxes.push(`    @top-center {
-      content: "${altLabel}";
-      color: ${altColor};
-      background: ${altBg};
-      border-bottom: 2px solid ${altColor};${BANNER_BASE}
-    }`);
+        altBoxes.push(`      @top-center {
+        content: "${altLabel}";
+        color: ${altColor};
+        background: ${altBg};
+        border-bottom: 2px solid ${altColor};${BANNER_BASE}
+      }`);
       }
       if (hasBottomBanner) {
-        altBoxes.push(`    @bottom-center {
-      content: "${altLabel}";
-      color: ${altColor};
-      background: ${altBg};
-      border-top: 2px solid ${altColor};${BANNER_BASE}
-    }`);
+        altBoxes.push(`      @bottom-center {
+        content: "${altLabel}";
+        color: ${altColor};
+        background: ${altBg};
+        border-top: 2px solid ${altColor};${BANNER_BASE}
+      }`);
       }
       if (altBoxes.length > 0) {
-        css += `\n@media print and (prefers-color-scheme: dark) {
-  @page {
+        autoOverride = `
+  @media (prefers-color-scheme: dark) {
+    @page {
 ${altBoxes.join('\n')}
-  }
-}`;
+    }
+  }`;
       }
     }
+
+    const css = `@media print {
+  @page {
+    margin: 1in !important;
+${marginBoxes.join('\n')}
+  }${autoOverride}
+}`;
 
     this.styleEl.textContent = css;
     console.debug('[yaae] PageChromeManager updated. CSS:', css);

--- a/src/document/settings-tab-helpers.ts
+++ b/src/document/settings-tab-helpers.ts
@@ -25,3 +25,26 @@ export function sanitizeClassificationId(input: string): string {
 export function isValidClassificationId(id: string): boolean {
   return /[a-z0-9]/.test(id);
 }
+
+/**
+ * Whether a font value is one of the named dropdown presets.
+ * Arbitrary strings (e.g. "Inter", "Helvetica Neue") return false and
+ * should be displayed via the "Custom" branch of the dropdown UI so a
+ * stray click on the dropdown doesn't silently overwrite the stored value.
+ */
+export function isFontPreset(
+  value: string,
+): value is 'sans' | 'serif' | 'mono' | 'system' {
+  switch (value) {
+    case 'sans':
+    case 'serif':
+    case 'mono':
+    case 'system':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** Sentinel value used by the font dropdown to surface a custom string. */
+export const FONT_CUSTOM_SENTINEL = 'custom';

--- a/src/document/settings-tab-helpers.ts
+++ b/src/document/settings-tab-helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure helpers extracted from settings-tab.ts for testability.
+ *
+ * These functions encapsulate validation and detection logic that drives
+ * settings UI behavior, so they can be unit tested without needing to render
+ * the actual Obsidian Setting UI.
+ */
+
+/**
+ * Sanitize a classification ID input into a slug-safe string.
+ * Lowercases, replaces whitespace runs with hyphens, strips non `[a-z0-9-]`.
+ *
+ * Note: This does NOT guarantee a meaningful ID. Use {@link isValidClassificationId}
+ * to gate persistence — whitespace-only input sanitizes to a hyphen.
+ */
+export function sanitizeClassificationId(input: string): string {
+  return input.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+/**
+ * Whether a sanitized classification ID is acceptable for persistence.
+ * Requires at least one alphanumeric character to reject inputs like
+ * "   " (which sanitizes to a hyphen) or "!@#" (which sanitizes to "").
+ */
+export function isValidClassificationId(id: string): boolean {
+  return /[a-z0-9]/.test(id);
+}

--- a/src/document/settings-tab-helpers.ts
+++ b/src/document/settings-tab-helpers.ts
@@ -8,13 +8,19 @@
 
 /**
  * Sanitize a classification ID input into a slug-safe string.
- * Lowercases, replaces whitespace runs with hyphens, strips non `[a-z0-9-]`.
- *
- * Note: This does NOT guarantee a meaningful ID. Use {@link isValidClassificationId}
- * to gate persistence — whitespace-only input sanitizes to a hyphen.
+ * Lowercases, replaces whitespace runs with hyphens, strips non `[a-z0-9-]`,
+ * collapses hyphen runs, and trims edge hyphens. The trim matters because
+ * leading/trailing whitespace in user paste must not become semantically
+ * significant — `' foo '` and `'foo'` resolve to the same ID.
  */
 export function sanitizeClassificationId(input: string): string {
-  return input.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /**
@@ -26,24 +32,19 @@ export function isValidClassificationId(id: string): boolean {
   return /[a-z0-9]/.test(id);
 }
 
+/** Named font dropdown presets. Source of truth — UI dropdown derives from this. */
+export const FONT_PRESETS = ['sans', 'serif', 'mono', 'system'] as const;
+
+export type FontPreset = (typeof FONT_PRESETS)[number];
+
 /**
  * Whether a font value is one of the named dropdown presets.
  * Arbitrary strings (e.g. "Inter", "Helvetica Neue") return false and
  * should be displayed via the "Custom" branch of the dropdown UI so a
  * stray click on the dropdown doesn't silently overwrite the stored value.
  */
-export function isFontPreset(
-  value: string,
-): value is 'sans' | 'serif' | 'mono' | 'system' {
-  switch (value) {
-    case 'sans':
-    case 'serif':
-    case 'mono':
-    case 'system':
-      return true;
-    default:
-      return false;
-  }
+export function isFontPreset(value: string): value is FontPreset {
+  return (FONT_PRESETS as readonly string[]).includes(value);
 }
 
 /** Sentinel value used by the font dropdown to surface a custom string. */

--- a/src/document/settings-tab.ts
+++ b/src/document/settings-tab.ts
@@ -9,6 +9,8 @@ import {
 import type { LinksMode, ThemeMode } from './settings';
 import { createCollapsibleSection } from '../settings/collapsible-section';
 import {
+  FONT_CUSTOM_SENTINEL,
+  isFontPreset,
   isValidClassificationId,
   sanitizeClassificationId,
 } from './settings-tab-helpers';
@@ -249,6 +251,36 @@ export function renderDocumentSettings(
         }),
     );
 
+  // Font family: named presets pipe to static CSS classes; arbitrary strings
+  // go through DynamicPdfPrintStyleManager. The dropdown surfaces a
+  // "Custom..." option that reveals the text input row below — this prevents
+  // the prior bug where opening the dropdown to inspect would silently
+  // overwrite an arbitrary `fontFamily` (e.g. "Inter") with "sans" because
+  // the dropdown fell back to "sans" on first render.
+  const currentFont = plugin.settings.document.fontFamily;
+  const fontIsCustom = !isFontPreset(currentFont);
+
+  // Build the custom-font row first so we can reference its element from
+  // the dropdown's onChange handler.
+  let focusCustomFontInput: (() => void) | null = null;
+  const customFontRow = new Setting(appearanceContent)
+    .setName('Custom font')
+    .setDesc('Comma-separated font stack (e.g., "Inter", -apple-system, sans-serif).')
+    .addText((text) => {
+      focusCustomFontInput = () => text.inputEl.focus();
+      text
+        .setPlaceholder('"Inter", -apple-system, sans-serif')
+        .setValue(fontIsCustom ? currentFont : '')
+        .onChange(async (value) => {
+          const trimmed = value.trim();
+          if (!trimmed) return;
+          plugin.settings.document.fontFamily = trimmed;
+          plugin.dynamicPdfPrintStyles.update(plugin.settings.document);
+          await plugin.saveSettings();
+        });
+    });
+  if (!fontIsCustom) customFontRow.settingEl.setAttribute('hidden', '');
+
   new Setting(appearanceContent)
     .setName('Font family')
     .setDesc('Font stack for PDF export. Named presets use safe system fonts.')
@@ -258,15 +290,22 @@ export function renderDocumentSettings(
         .addOption('serif', 'Serif')
         .addOption('mono', 'Monospace')
         .addOption('system', 'System default')
-        .setValue(
-          ['sans', 'serif', 'mono', 'system'].includes(plugin.settings.document.fontFamily)
-            ? plugin.settings.document.fontFamily
-            : 'sans'
-        )
+        .addOption(FONT_CUSTOM_SENTINEL, 'Custom...')
+        .setValue(fontIsCustom ? FONT_CUSTOM_SENTINEL : currentFont)
         .onChange(async (value) => {
+          if (value === FONT_CUSTOM_SENTINEL) {
+            // Reveal the custom input but DO NOT overwrite the stored
+            // fontFamily. If the stored value was already a custom string,
+            // this is a no-op for state; if it was a preset, the user must
+            // type a value before anything is persisted.
+            customFontRow.settingEl.removeAttribute('hidden');
+            focusCustomFontInput?.();
+            return;
+          }
           plugin.settings.document.fontFamily = value;
           plugin.dynamicPdfPrintStyles.update(plugin.settings.document);
           await plugin.saveSettings();
+          customFontRow.settingEl.setAttribute('hidden', '');
         }),
     );
 

--- a/src/document/settings-tab.ts
+++ b/src/document/settings-tab.ts
@@ -134,14 +134,26 @@ export function renderDocumentSettings(
           .onChange(async (value) => {
             entry.id = sanitizeClassificationId(value);
             const valid = isValidClassificationId(entry.id);
-            row.setDesc(
-              valid
-                ? `Frontmatter value: ${entry.id}`
-                : 'ID required — at least one letter or digit',
+            // Frontmatter resolution returns the first matching custom, so a
+            // duplicate ID silently shadows the older entry. Block save on
+            // collision and surface the conflict instead.
+            const duplicate = valid && customs.some(
+              (c, i) =>
+                c.id === entry.id &&
+                !(source.kind === 'persisted' && i === source.index),
             );
-            row.settingEl.toggleClass('is-invalid', !valid);
+            row.setDesc(
+              !valid
+                ? 'ID required — at least one letter or digit'
+                : duplicate
+                  ? `ID "${entry.id}" already in use — choose a different ID`
+                  : `Frontmatter value: ${entry.id}`,
+            );
+            row.settingEl.toggleClass('is-invalid', !valid || duplicate);
 
-            if (source.kind === 'draft' && valid) {
+            if (!valid || duplicate) return;
+
+            if (source.kind === 'draft') {
               // Commit the draft into the persisted list. Re-render so the
               // row is now backed by the array (gets a real index, trash
               // button works, future edits hit the correct slot).
@@ -152,10 +164,7 @@ export function renderDocumentSettings(
               return;
             }
 
-            if (source.kind === 'persisted' && valid) {
-              await saveAndRefreshPrintStyles();
-            }
-            // Otherwise: invalid ID — keep editing in memory, do not persist.
+            await saveAndRefreshPrintStyles();
           }),
       );
 

--- a/src/document/settings-tab.ts
+++ b/src/document/settings-tab.ts
@@ -3,6 +3,7 @@ import type YaaePlugin from '../../main';
 import {
   getAllClassificationIds,
   getClassificationMeta,
+  type CustomClassification,
   type WatermarkLevel,
 } from '../schemas';
 import type { LinksMode, ThemeMode } from './settings';
@@ -88,16 +89,41 @@ export function renderDocumentSettings(
     plugin.pageChromeManager.update(plugin.buildPageChromeState());
   }
 
+  // Draft entry for the "Add classification" flow. Held outside
+  // `customClassifications` until it has a valid ID, so partial entries
+  // never get persisted to disk (and an interrupted edit can't load a
+  // half-written `id: ''` row on next reload).
+  let draftEntry: CustomClassification | null = null;
+
   function renderCustomClassifications() {
     customListEl.empty();
     const customs = plugin.settings.document.customClassifications;
 
-    for (let i = 0; i < customs.length; i++) {
-      const entry = customs[i];
+    type RowSource =
+      | { kind: 'persisted'; entry: CustomClassification; index: number }
+      | { kind: 'draft'; entry: CustomClassification };
+
+    const rows: RowSource[] = customs.map((entry, index) => ({
+      kind: 'persisted',
+      entry,
+      index,
+    }));
+    if (draftEntry) rows.push({ kind: 'draft', entry: draftEntry });
+
+    for (const source of rows) {
+      const entry = source.entry;
+      const isDraft = source.kind === 'draft';
 
       const row = new Setting(customListEl)
         .setName(entry.label || entry.id || 'New classification')
-        .setDesc(entry.id ? `Frontmatter value: ${entry.id}` : '');
+        .setDesc(
+          isDraft
+            ? 'ID required — type a slug (e.g., non-sensitive)'
+            : entry.id
+              ? `Frontmatter value: ${entry.id}`
+              : '',
+        );
+      if (isDraft) row.settingEl.toggleClass('is-invalid', true);
 
       row.addText((text) =>
         text
@@ -112,7 +138,22 @@ export function renderDocumentSettings(
                 : 'ID required — at least one letter or digit',
             );
             row.settingEl.toggleClass('is-invalid', !valid);
-            if (valid) await saveAndRefreshPrintStyles();
+
+            if (source.kind === 'draft' && valid) {
+              // Commit the draft into the persisted list. Re-render so the
+              // row is now backed by the array (gets a real index, trash
+              // button works, future edits hit the correct slot).
+              customs.push(entry);
+              draftEntry = null;
+              await saveAndRefreshPrintStyles();
+              renderCustomClassifications();
+              return;
+            }
+
+            if (source.kind === 'persisted' && valid) {
+              await saveAndRefreshPrintStyles();
+            }
+            // Otherwise: invalid ID — keep editing in memory, do not persist.
           }),
       );
 
@@ -123,14 +164,21 @@ export function renderDocumentSettings(
           .onChange(async (value) => {
             entry.label = value;
             row.setName(value || entry.id || 'New classification');
-            await saveAndRefreshPrintStyles();
+            // Only persist when the entry has a real, valid ID. Drafts and
+            // entries with placeholder IDs stay in memory until a valid ID
+            // is typed.
+            if (!isDraft && isValidClassificationId(entry.id)) {
+              await saveAndRefreshPrintStyles();
+            }
           }),
       );
 
       const colorPicker = row.addColorPicker((picker) =>
         picker.setValue(entry.color).onChange(async (value) => {
           entry.color = value;
-          await saveAndRefreshPrintStyles();
+          if (!isDraft && isValidClassificationId(entry.id)) {
+            await saveAndRefreshPrintStyles();
+          }
         }),
       );
       setTooltip(colorPicker.colorPickerEl, 'Text color');
@@ -138,33 +186,43 @@ export function renderDocumentSettings(
       const bgPicker = row.addColorPicker((picker) =>
         picker.setValue(entry.background).onChange(async (value) => {
           entry.background = value;
-          await saveAndRefreshPrintStyles();
+          if (!isDraft && isValidClassificationId(entry.id)) {
+            await saveAndRefreshPrintStyles();
+          }
         }),
       );
       setTooltip(bgPicker.colorPickerEl, 'Background color');
 
       row.addExtraButton((btn) =>
         btn.setIcon('trash').setTooltip('Remove').onClick(async () => {
-          customs.splice(i, 1);
+          if (source.kind === 'draft') {
+            draftEntry = null;
+            renderCustomClassifications();
+            return;
+          }
+          customs.splice(source.index, 1);
           await saveAndRefreshPrintStyles();
           renderCustomClassifications();
         }),
       );
     }
 
-    // Add button
-    new Setting(customListEl).addButton((btn) =>
-      btn.setButtonText('Add classification').onClick(async () => {
-        customs.push({
+    // "Add classification" creates an in-memory draft only — disabled while
+    // a draft is already pending so the UI stays honest about what's
+    // persisted vs. what's still being typed.
+    new Setting(customListEl).addButton((btn) => {
+      btn.setButtonText('Add classification').onClick(() => {
+        if (draftEntry) return;
+        draftEntry = {
           id: '',
           label: '',
           color: '#666666',
           background: '#f5f5f5',
-        });
-        await plugin.saveSettings();
+        };
         renderCustomClassifications();
-      }),
-    );
+      });
+      if (draftEntry) btn.setDisabled(true);
+    });
   }
 
   renderCustomClassifications();

--- a/src/document/settings-tab.ts
+++ b/src/document/settings-tab.ts
@@ -124,7 +124,7 @@ export function renderDocumentSettings(
           await saveAndRefreshPrintStyles();
         }),
       );
-      setTooltip(colorPicker.colorPickerEl, 'Text color');
+      setTooltip(colorPicker.colorPickerEl, 'Light theme — text color');
 
       const bgPicker = row.addColorPicker((picker) =>
         picker.setValue(entry.background).onChange(async (value) => {
@@ -132,11 +132,43 @@ export function renderDocumentSettings(
           await saveAndRefreshPrintStyles();
         }),
       );
-      setTooltip(bgPicker.colorPickerEl, 'Background color');
+      setTooltip(bgPicker.colorPickerEl, 'Light theme — background color');
 
       row.addExtraButton((btn) =>
         btn.setIcon('trash').setTooltip('Remove').onClick(async () => {
           customs.splice(i, 1);
+          await saveAndRefreshPrintStyles();
+          renderCustomClassifications();
+        }),
+      );
+
+      // Dark-theme overrides — second row, optional. Empty = inherit from light.
+      const darkRow = new Setting(customListEl)
+        .setClass('yaae-classification-dark-row')
+        .setName('')
+        .setDesc('Dark theme (leave at defaults to inherit light values)');
+
+      const darkColorPicker = darkRow.addColorPicker((picker) =>
+        picker.setValue(entry.colorDark ?? entry.color).onChange(async (value) => {
+          entry.colorDark = value;
+          await saveAndRefreshPrintStyles();
+        }),
+      );
+      setTooltip(darkColorPicker.colorPickerEl, 'Dark theme — text color');
+
+      const darkBgPicker = darkRow.addColorPicker((picker) =>
+        picker.setValue(entry.backgroundDark ?? entry.background).onChange(async (value) => {
+          entry.backgroundDark = value;
+          await saveAndRefreshPrintStyles();
+        }),
+      );
+      setTooltip(darkBgPicker.colorPickerEl, 'Dark theme — background color');
+
+      // Reset to inherit-from-light
+      darkRow.addExtraButton((btn) =>
+        btn.setIcon('reset').setTooltip('Reset dark colors (inherit from light)').onClick(async () => {
+          entry.colorDark = undefined;
+          entry.backgroundDark = undefined;
           await saveAndRefreshPrintStyles();
           renderCustomClassifications();
         }),

--- a/src/document/settings-tab.ts
+++ b/src/document/settings-tab.ts
@@ -7,6 +7,10 @@ import {
 } from '../schemas';
 import type { LinksMode, ThemeMode } from './settings';
 import { createCollapsibleSection } from '../settings/collapsible-section';
+import {
+  isValidClassificationId,
+  sanitizeClassificationId,
+} from './settings-tab-helpers';
 
 /**
  * Render the Document settings section into the plugin settings tab.
@@ -100,10 +104,15 @@ export function renderDocumentSettings(
           .setPlaceholder('ID (e.g., non-sensitive)')
           .setValue(entry.id)
           .onChange(async (value) => {
-            entry.id = value.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-            row.setDesc(entry.id ? `Frontmatter value: ${entry.id}` : 'ID required');
-            row.settingEl.toggleClass('is-invalid', !entry.id);
-            if (entry.id) await saveAndRefreshPrintStyles();
+            entry.id = sanitizeClassificationId(value);
+            const valid = isValidClassificationId(entry.id);
+            row.setDesc(
+              valid
+                ? `Frontmatter value: ${entry.id}`
+                : 'ID required — at least one letter or digit',
+            );
+            row.settingEl.toggleClass('is-invalid', !valid);
+            if (valid) await saveAndRefreshPrintStyles();
           }),
       );
 

--- a/src/document/toc-generator.ts
+++ b/src/document/toc-generator.ts
@@ -9,13 +9,49 @@ interface TocEntry {
   slug: string;
 }
 
-/** Convert heading text to GitHub-compatible anchor slug */
+/**
+ * Strip markdown inline syntax to recover plain rendered text. Used for both
+ * slug generation and TOC display so anchors and labels match what Obsidian
+ * actually renders for the heading.
+ */
+function stripInlineMarkdown(text: string): string {
+  return (
+    text
+      // Footnote references: [^1] → ''
+      .replace(/\[\^[^\]]+\]/g, '')
+      // Image links: ![alt](url) → alt
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Wikilink with display: [[target|display]] → display
+      .replace(/\[\[[^\]|]+\|([^\]]+)\]\]/g, '$1')
+      // Plain wikilink: [[target]] → target
+      .replace(/\[\[([^\]]+)\]\]/g, '$1')
+      // Inline link: [text](url) → text
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      // Inline code: `code` → code
+      .replace(/`([^`]+)`/g, '$1')
+      // Inline math: $expr$ → expr
+      .replace(/\$([^$]+)\$/g, '$1')
+      // Bold/italic markers: **text** / *text* / __text__ / _text_
+      .replace(/(\*\*|__)(.+?)\1/g, '$2')
+      .replace(/(\*|_)([^*_]+?)\1/g, '$2')
+      .trim()
+  );
+}
+
+/**
+ * Convert heading text to an Obsidian-compatible anchor slug.
+ *
+ * Obsidian's heading anchors lowercase the text, replace whitespace runs
+ * with single hyphens, and strip non-alphanumeric characters except hyphens.
+ * Inline markdown is stripped first so headings like `## Foo [bar](./b.md)`
+ * produce `foo-bar`, not a broken anchor with link punctuation embedded.
+ */
 function slugify(text: string): string {
-  return text
+  return stripInlineMarkdown(text)
     .toLowerCase()
     .replace(/[^\w\s-]/g, '')
     .replace(/\s+/g, '-')
-    .trim();
+    .replace(/^-+|-+$/g, '');
 }
 
 /** Parse headings from markdown, skipping frontmatter and code blocks */
@@ -27,8 +63,10 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
   let frontmatterClosed = false;
 
   for (const line of lines) {
-    // Track frontmatter
-    if (line.trim() === '---') {
+    // Track frontmatter — open and close markers must be exactly `---` with
+    // no leading whitespace, otherwise an indented `---` inside a YAML block
+    // scalar (e.g. `description: |\n  ---`) would be misread as a fence.
+    if (line === '---') {
       if (!frontmatterClosed) {
         inFrontmatter = !inFrontmatter;
         if (!inFrontmatter) frontmatterClosed = true;
@@ -37,8 +75,8 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
     }
     if (inFrontmatter) continue;
 
-    // Track code blocks
-    if (line.trim().startsWith('```')) {
+    // Track code blocks (both backtick and tilde fences)
+    if (/^(```|~~~)/.test(line.trimStart())) {
       inCodeBlock = !inCodeBlock;
       continue;
     }
@@ -48,13 +86,14 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
     const match = line.match(/^(#{1,6})\s+(.+)$/);
     if (match) {
       const level = match[1].length;
-      const text = match[2].trim();
+      const rawText = match[2].trim();
+      const displayText = stripInlineMarkdown(rawText);
 
       // Skip the TOC heading itself
-      if (text === 'Table of Contents') continue;
+      if (displayText === 'Table of Contents') continue;
 
       if (level <= maxDepth) {
-        entries.push({ level, text, slug: slugify(text) });
+        entries.push({ level, text: displayText, slug: slugify(rawText) });
       }
     }
   }
@@ -66,8 +105,14 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
 function buildTocBlock(entries: TocEntry[]): string {
   const lines = ['## Table of Contents', ''];
 
+  // Indent relative to the shallowest heading we saw — H1 then H3 with no H2
+  // should still nest by one level, not by two.
+  const minLevel =
+    entries.length > 0 ? Math.min(...entries.map((e) => e.level)) : 1;
+
   for (const entry of entries) {
-    const indent = '  '.repeat(entry.level - 1);
+    const depth = Math.max(0, entry.level - minLevel);
+    const indent = '  '.repeat(depth);
     lines.push(`${indent}- [${entry.text}](#${entry.slug})`);
   }
 
@@ -77,6 +122,25 @@ function buildTocBlock(entries: TocEntry[]): string {
 
 /** TOC block detection pattern: ## Table of Contents ... --- */
 const TOC_PATTERN = /## Table of Contents\n[\s\S]*?\n---/;
+
+/**
+ * Locate the line index of the frontmatter close marker (`---`).
+ *
+ * Walks line-by-line so block scalars containing literal `---` (e.g.
+ * `description: |\n  ---\n  divider\n`) don't trick us into treating an
+ * embedded `---` as the close marker. The open and close markers must be
+ * exactly `---` with no leading whitespace — indented content inside a YAML
+ * block scalar is part of the value, not a fence. Returns `-1` if no
+ * frontmatter is present (or if the block never closes).
+ */
+function findFrontmatterCloseLine(lines: string[]): number {
+  if (lines.length === 0 || lines[0] !== '---') return -1;
+
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') return i;
+  }
+  return -1;
+}
 
 /**
  * Generate or replace the Table of Contents in markdown content.
@@ -97,12 +161,12 @@ export function generateToc(
     };
   }
 
-  // Insert after frontmatter closing ---
-  const fmClose = content.indexOf('---', content.indexOf('---') + 3);
-  if (fmClose !== -1) {
-    const insertPos = fmClose + 3;
-    const before = content.slice(0, insertPos);
-    const after = content.slice(insertPos);
+  // Insert after frontmatter close, if any
+  const lines = content.split('\n');
+  const fmCloseLine = findFrontmatterCloseLine(lines);
+  if (fmCloseLine !== -1) {
+    const before = lines.slice(0, fmCloseLine + 1).join('\n');
+    const after = lines.slice(fmCloseLine + 1).join('\n');
     return {
       content: `${before}\n\n${tocBlock}\n${after}`,
       entryCount: entries.length,

--- a/src/document/toc-generator.ts
+++ b/src/document/toc-generator.ts
@@ -59,7 +59,7 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
   const lines = content.split('\n');
   const entries: TocEntry[] = [];
   let inFrontmatter = false;
-  let inCodeBlock = false;
+  let activeFence: '```' | '~~~' | null = null;
   let frontmatterClosed = false;
 
   for (const line of lines) {
@@ -75,12 +75,17 @@ function parseHeadings(content: string, maxDepth: number): TocEntry[] {
     }
     if (inFrontmatter) continue;
 
-    // Track code blocks (both backtick and tilde fences)
-    if (/^(```|~~~)/.test(line.trimStart())) {
-      inCodeBlock = !inCodeBlock;
+    // Track code blocks. A `~~~` line inside a backtick fence (or vice versa)
+    // must NOT close the outer block, so track which marker opened the fence
+    // and only close on a matching marker.
+    const fenceMatch = line.trimStart().match(/^(```+|~~~+)/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1].startsWith('`') ? '```' : '~~~';
+      if (activeFence === null) activeFence = marker;
+      else if (activeFence === marker) activeFence = null;
       continue;
     }
-    if (inCodeBlock) continue;
+    if (activeFence !== null) continue;
 
     // Match headings
     const match = line.match(/^(#{1,6})\s+(.+)$/);

--- a/src/prose-highlight/pos-styles.ts
+++ b/src/prose-highlight/pos-styles.ts
@@ -13,13 +13,15 @@ const STYLE_ID = 'yaae-prose-highlight-styles';
 export class POSStyleManager {
   private styleEl: HTMLStyleElement | null = null;
 
-  /** Create the <style> element, run one-shot POS migration, inject rules */
-  init(settings: ProseHighlightSettings): void {
+  /** Create the <style> element, run one-shot POS migration, inject rules.
+   * Returns true when migration ran (caller should persist settings). */
+  init(settings: ProseHighlightSettings): boolean {
     this.styleEl = document.createElement('style');
     this.styleEl.id = STYLE_ID;
     document.head.appendChild(this.styleEl);
-    this.migrateLegacyPOSColors(settings);
+    const migrated = this.migrateLegacyPOSColors(settings);
     this.update(settings);
+    return migrated;
   }
 
   /** Regenerate dynamic rules — only custom word lists need <style> injection */
@@ -41,14 +43,27 @@ export class POSStyleManager {
    * light/dark refactor. Writes legacy single-value colors to the new
    * `-light` variant via body.style so they keep their look. Dark variant
    * gets the new default; user can adjust via Style Settings or theme CSS.
+   *
+   * Latched by `settings.posColorsMigrated` so subsequent reloads do not
+   * re-stamp inline styles — that would clobber any Style Settings user
+   * overrides since inline body styles outrank stylesheet declarations.
+   * Caller is expected to persist the mutated flag via saveSettings().
+   *
+   * Returns true if migration ran for the first time (i.e. the caller
+   * should persist settings); false otherwise.
    */
-  private migrateLegacyPOSColors(settings: ProseHighlightSettings): void {
+  private migrateLegacyPOSColors(settings: ProseHighlightSettings): boolean {
+    if (settings.posColorsMigrated) return false;
+
     for (const cat of POS_CATEGORIES) {
       const legacy = settings.categories[cat]?.color;
       if (legacy && legacy !== DEFAULT_POS_COLORS[cat]) {
         document.body.style.setProperty(`--yaae-pos-${cat}-color-light`, legacy);
       }
     }
+
+    settings.posColorsMigrated = true;
+    return true;
   }
 
   /** Remove the <style> element from the DOM */

--- a/src/prose-highlight/pos-styles.ts
+++ b/src/prose-highlight/pos-styles.ts
@@ -26,6 +26,7 @@ export class POSStyleManager {
     document.head.appendChild(this.styleEl);
     const migrated = this.migrateLegacyPOSColors(settings);
     this.update(settings);
+    console.debug('[yaae] POSStyleManager initialized.');
     return migrated;
   }
 
@@ -78,6 +79,7 @@ export class POSStyleManager {
     }
 
     settings.posColorsMigrated = true;
+    console.info('[yaae] Migrated legacy POS colors to light/dark CSS variables.');
     return true;
   }
 

--- a/src/prose-highlight/pos-styles.ts
+++ b/src/prose-highlight/pos-styles.ts
@@ -14,8 +14,13 @@ export class POSStyleManager {
   private styleEl: HTMLStyleElement | null = null;
 
   /** Create the <style> element, run one-shot POS migration, inject rules.
-   * Returns true when migration ran (caller should persist settings). */
+   * Re-init is idempotent: any prior <style> is removed first so a
+   * partial-init failure or hot reload cannot leave orphaned elements
+   * behind. Returns true when migration ran (caller should persist). */
   init(settings: ProseHighlightSettings): boolean {
+    if (this.styleEl) {
+      this.destroy();
+    }
     this.styleEl = document.createElement('style');
     this.styleEl.id = STYLE_ID;
     document.head.appendChild(this.styleEl);

--- a/src/prose-highlight/pos-styles.ts
+++ b/src/prose-highlight/pos-styles.ts
@@ -1,6 +1,6 @@
 import type { ProseHighlightSettings } from '../types';
 import { POS_CATEGORIES } from '../types';
-import { sanitizeListName } from './word-lists';
+import { buildUniqueClassSuffixes } from './word-lists';
 
 const STYLE_ID = 'yaae-prose-highlight-styles';
 
@@ -35,9 +35,16 @@ export class POSStyleManager {
     }
     rules.push(`body { ${varDecls.join(' ')} }`);
 
-    // Custom word list colors (fully dynamic — no static rules)
-    for (const list of settings.customWordLists) {
-      const cls = sanitizeListName(list.name);
+    // Custom word list colors (fully dynamic — no static rules). Use the
+    // same dedup logic as WordListMatcher so collisions (e.g. "My List" and
+    // "my-list") get distinct classes here AND in the highlighter, instead
+    // of one rule silently overwriting the other.
+    const suffixes = buildUniqueClassSuffixes(
+      settings.customWordLists.map((l) => l.name),
+    );
+    for (let i = 0; i < settings.customWordLists.length; i++) {
+      const list = settings.customWordLists[i];
+      const cls = suffixes[i];
       if (cls) {
         rules.push(`.yaae-list-${cls} { color: ${list.color}; }`);
       }

--- a/src/prose-highlight/pos-styles.ts
+++ b/src/prose-highlight/pos-styles.ts
@@ -1,49 +1,54 @@
 import type { ProseHighlightSettings } from '../types';
-import { POS_CATEGORIES } from '../types';
+import { POS_CATEGORIES, DEFAULT_POS_COLORS } from '../types';
 import { sanitizeListName } from './word-lists';
 
 const STYLE_ID = 'yaae-prose-highlight-styles';
 
 /**
- * Manages a dynamic <style> element for POS and custom word list colors.
- * Updating colors only changes CSS rules — no decoration rebuilds needed.
+ * Manages a dynamic <style> element for custom word list colors.
+ * POS category colors are now defined in styles.css via layered CSS
+ * variables (--yaae-pos-*-color-{light,dark}); see Style Settings YAML
+ * and theme overrides.
  */
 export class POSStyleManager {
   private styleEl: HTMLStyleElement | null = null;
 
-  /** Create the <style> element and inject initial rules */
+  /** Create the <style> element, run one-shot POS migration, inject rules */
   init(settings: ProseHighlightSettings): void {
     this.styleEl = document.createElement('style');
     this.styleEl.id = STYLE_ID;
     document.head.appendChild(this.styleEl);
+    this.migrateLegacyPOSColors(settings);
     this.update(settings);
   }
 
-  /** Regenerate all CSS rules from current settings */
+  /** Regenerate dynamic rules — only custom word lists need <style> injection */
   update(settings: ProseHighlightSettings): void {
     if (!this.styleEl) return;
 
     const rules: string[] = [];
-
-    // POS category colors — set CSS custom properties so the static
-    // class rules in styles.css (`.yaae-pos-adjective { color: var(--…) }`)
-    // pick up user overrides from the plugin settings UI.
-    const varDecls: string[] = [];
-    for (const cat of POS_CATEGORIES) {
-      const catSettings = settings.categories[cat];
-      varDecls.push(`--yaae-pos-${cat}-color: ${catSettings.color};`);
-    }
-    rules.push(`body { ${varDecls.join(' ')} }`);
-
-    // Custom word list colors (fully dynamic — no static rules)
     for (const list of settings.customWordLists) {
       const cls = sanitizeListName(list.name);
       if (cls) {
         rules.push(`.yaae-list-${cls} { color: ${list.color}; }`);
       }
     }
-
     this.styleEl.textContent = rules.join('\n');
+  }
+
+  /**
+   * One-shot migration for users who customized POS colors before the
+   * light/dark refactor. Writes legacy single-value colors to the new
+   * `-light` variant via body.style so they keep their look. Dark variant
+   * gets the new default; user can adjust via Style Settings or theme CSS.
+   */
+  private migrateLegacyPOSColors(settings: ProseHighlightSettings): void {
+    for (const cat of POS_CATEGORIES) {
+      const legacy = settings.categories[cat]?.color;
+      if (legacy && legacy !== DEFAULT_POS_COLORS[cat]) {
+        document.body.style.setProperty(`--yaae-pos-${cat}-color-light`, legacy);
+      }
+    }
   }
 
   /** Remove the <style> element from the DOM */

--- a/src/prose-highlight/reading-view.ts
+++ b/src/prose-highlight/reading-view.ts
@@ -4,7 +4,7 @@ import { CompromiseTagger } from './tagger';
 import { WordListMatcher } from './word-lists';
 import type { POSTag } from './tagger';
 import type { WordListMatch } from './word-lists';
-import type { POSCategory } from '../types';
+import type { CustomWordList, POSCategory } from '../types';
 
 /** Elements whose text content should not be processed */
 const SKIP_SELECTORS = 'code, pre, .frontmatter, .metadata-container, th, .math, .MathJax';
@@ -22,17 +22,31 @@ const POS_CLASS: Record<POSCategory, string> = {
  * Creates a MarkdownPostProcessor that highlights prose in Reading View.
  * Uses TreeWalker to find text nodes, runs POS tagger + word list matcher,
  * then wraps matched words in <span> elements with CSS classes.
+ *
+ * The tagger and matcher are constructed once and reused across blocks.
+ * Word-list regexes are only recompiled when the underlying settings array
+ * reference changes — a 40-block document with 5 lists × 50 words used to
+ * trigger 200 regex compiles per render; now it triggers one (or zero on a
+ * settings-stable run).
  */
 export function createReadingViewPostProcessor(plugin: YaaePlugin) {
   const tagger = new CompromiseTagger();
   const listMatcher = new WordListMatcher();
+  let compiledFor: CustomWordList[] | null = null;
+
+  function ensureCompiled(lists: CustomWordList[]): void {
+    if (compiledFor === lists) return;
+    listMatcher.compile(lists);
+    compiledFor = lists;
+  }
 
   return (el: HTMLElement, _ctx: MarkdownPostProcessorContext) => {
     const settings = plugin.settings.proseHighlight;
     if (!settings.enabled || !settings.readingViewEnabled) return;
 
-    // Recompile word lists (cheap if unchanged, safe if settings changed)
-    listMatcher.compile(settings.customWordLists);
+    // Recompile only when the settings array reference changes. Tests and
+    // production both rely on Obsidian replacing the array on save.
+    ensureCompiled(settings.customWordLists);
 
     // Collect text nodes, skipping code/pre/frontmatter
     const textNodes: Text[] = [];
@@ -104,7 +118,7 @@ export function createReadingViewPostProcessor(plugin: YaaePlugin) {
   };
 }
 
-interface HighlightSpan {
+export interface HighlightSpan {
   start: number;
   end: number;
   cssClass: string;
@@ -113,8 +127,13 @@ interface HighlightSpan {
 /**
  * Merge POS tags and word list matches into non-overlapping spans.
  * Word list matches take precedence over POS tags.
+ *
+ * Overlap is checked per-character, not just at the tag's start. A list
+ * match like "oo" inside the POS tag "good" must suppress the tag even
+ * though the tag's start position is outside the list match — otherwise
+ * both spans get emitted and the resulting DOM fragment is corrupt.
  */
-function buildSpans(
+export function buildSpans(
   posTags: POSTag[],
   listMatches: WordListMatch[],
   settings: { categories: Record<POSCategory, { enabled: boolean }> },
@@ -128,10 +147,19 @@ function buildSpans(
     for (let i = m.start; i < m.end; i++) covered.add(i);
   }
 
-  // Add POS tags that don't overlap with list matches
+  // Add POS tags that don't overlap with list matches.
   for (const tag of posTags) {
     if (!settings.categories[tag.pos]?.enabled) continue;
-    if (covered.has(tag.start)) continue;
+
+    let overlaps = false;
+    for (let p = tag.start; p < tag.end; p++) {
+      if (covered.has(p)) {
+        overlaps = true;
+        break;
+      }
+    }
+    if (overlaps) continue;
+
     spans.push({
       start: tag.start,
       end: tag.end,

--- a/src/prose-highlight/settings-tab.ts
+++ b/src/prose-highlight/settings-tab.ts
@@ -1,6 +1,6 @@
 import { Setting } from 'obsidian';
 import type YaaePlugin from '../../main';
-import { POS_CATEGORIES, DEFAULT_POS_COLORS } from '../types';
+import { POS_CATEGORIES } from '../types';
 import type { POSCategory, CustomWordList } from '../types';
 import { createCollapsibleSection } from '../settings/collapsible-section';
 
@@ -64,10 +64,19 @@ export function renderProseHighlightSettings(
     containerEl, expandedSections, 'writing-pos', 'Parts of Speech',
   );
 
+  const hint = posContent.createEl('p', { cls: 'setting-item-description' });
+  hint.appendText('Toggle which categories highlight. Customize colors via the ');
+  hint.createEl('strong', { text: 'Style Settings' });
+  hint.appendText(' plugin, or override ');
+  hint.createEl('code', { text: '--yaae-pos-*-color-light' });
+  hint.appendText(' / ');
+  hint.createEl('code', { text: '-dark' });
+  hint.appendText(' in your theme or CSS snippet.');
+
   for (const cat of POS_CATEGORIES) {
     const catSettings = settings.categories[cat];
 
-    const setting = new Setting(posContent)
+    new Setting(posContent)
       .setName(POS_LABELS[cat])
       .addToggle((toggle) =>
         toggle.setValue(catSettings.enabled).onChange(async (value) => {
@@ -76,31 +85,6 @@ export function renderProseHighlightSettings(
           plugin.refreshHighlighting();
         }),
       );
-
-    // Color picker via native <input type="color">
-    const colorInput = setting.controlEl.createEl('input', {
-      type: 'color',
-      value: catSettings.color,
-    });
-    colorInput.style.marginLeft = '8px';
-    colorInput.style.cursor = 'pointer';
-    colorInput.addEventListener('input', async () => {
-      catSettings.color = colorInput.value;
-      await plugin.saveSettings();
-      plugin.refreshStyles();
-    });
-
-    // Reset color button
-    if (catSettings.color !== DEFAULT_POS_COLORS[cat]) {
-      setting.addButton((btn) =>
-        btn.setButtonText('Reset').onClick(async () => {
-          catSettings.color = DEFAULT_POS_COLORS[cat];
-          colorInput.value = DEFAULT_POS_COLORS[cat];
-          await plugin.saveSettings();
-          plugin.refreshStyles();
-        }),
-      );
-    }
   }
 
   // --- Custom Word Lists section ---

--- a/src/prose-highlight/word-lists.ts
+++ b/src/prose-highlight/word-lists.ts
@@ -76,6 +76,7 @@ export class WordListMatcher {
 
   /** Recompile regexes from the current list definitions */
   compile(lists: CustomWordList[]): void {
+    console.debug(`[yaae] Preparing to compile word lists. Count: ${lists.length}`);
     this.compiled = [];
 
     // Compute unique class suffixes once so collisions get distinct classes
@@ -109,6 +110,7 @@ export class WordListMatcher {
         regex,
       });
     }
+    console.debug(`[yaae] Word lists compiled. Active: ${this.compiled.length}/${lists.length}`);
   }
 
   /** Match all compiled lists against text, returning non-overlapping matches */

--- a/src/prose-highlight/word-lists.ts
+++ b/src/prose-highlight/word-lists.ts
@@ -23,6 +23,46 @@ export function sanitizeListName(name: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+/**
+ * Build a map from each list's display name to a unique sanitized class
+ * suffix. Two lists whose names sanitize to the same value (e.g. `"My List"`
+ * and `"my-list"`) would otherwise share a class — POSStyleManager would
+ * emit two `color` rules and the second would silently win, leaving one
+ * list visually unstyled. Collisions get a numeric suffix: `my-list`,
+ * `my-list-2`, `my-list-3`, …
+ *
+ * Empty results (whitespace-only names that sanitize to `""`) are returned
+ * as `""` so callers keep their existing skip-on-empty behavior.
+ */
+export function buildUniqueClassSuffixes(
+  names: readonly string[],
+): string[] {
+  const used = new Set<string>();
+  const suffixes: string[] = [];
+
+  for (const name of names) {
+    const base = sanitizeListName(name);
+    if (!base) {
+      suffixes.push('');
+      continue;
+    }
+
+    if (!used.has(base)) {
+      used.add(base);
+      suffixes.push(base);
+      continue;
+    }
+
+    let n = 2;
+    while (used.has(`${base}-${n}`)) n++;
+    const unique = `${base}-${n}`;
+    used.add(unique);
+    suffixes.push(unique);
+  }
+
+  return suffixes;
+}
+
 /** Escape special regex characters in a string */
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -37,7 +77,13 @@ export class WordListMatcher {
   /** Recompile regexes from the current list definitions */
   compile(lists: CustomWordList[]): void {
     this.compiled = [];
-    for (const list of lists) {
+
+    // Compute unique class suffixes once so collisions get distinct classes
+    // instead of silently sharing one (and fighting over the color rule).
+    const suffixes = buildUniqueClassSuffixes(lists.map((l) => l.name));
+
+    for (let i = 0; i < lists.length; i++) {
+      const list = lists[i];
       if (!list.enabled || list.words.length === 0) continue;
 
       // Sort by length descending so longer phrases match first
@@ -47,13 +93,16 @@ export class WordListMatcher {
 
       if (sorted.length === 0) continue;
 
+      const suffix = suffixes[i];
+      if (!suffix) continue;
+
       const pattern = sorted.map(escapeRegex).join('|');
       const flags = list.caseSensitive ? 'g' : 'gi';
       const regex = new RegExp(`\\b(?:${pattern})\\b`, flags);
 
       this.compiled.push({
         name: list.name,
-        cssClass: `yaae-list-${sanitizeListName(list.name)}`,
+        cssClass: `yaae-list-${suffix}`,
         regex,
       });
     }

--- a/src/prose-highlight/word-lists.ts
+++ b/src/prose-highlight/word-lists.ts
@@ -98,6 +98,9 @@ export class WordListMatcher {
 
       const pattern = sorted.map(escapeRegex).join('|');
       const flags = list.caseSensitive ? 'g' : 'gi';
+      // ReDoS-safe: every entry is escapeRegex'd (literalizes `.*+?^${}()|[]\`),
+      // alternation is a non-capturing group, and `\b` doesn't backtrack.
+      // Adversarial input is moot — words come from this user's own settings.
       const regex = new RegExp(`\\b(?:${pattern})\\b`, flags);
 
       this.compiled.push({

--- a/src/schemas/classification.ts
+++ b/src/schemas/classification.ts
@@ -65,13 +65,23 @@ export const CLASSIFICATION_TAXONOMY: Record<BuiltinClassificationLevel, Classif
 /**
  * Look up classification metadata by level ID.
  * Custom classifications take precedence over built-in ones.
+ *
+ * The level value is trimmed before lookup so that frontmatter values
+ * like `"  internal  "` resolve identically here and in Zod-coerced call
+ * sites (e.g. PageChromeManager) — divergence between the two would let
+ * a banner silently disappear in reading view while still appearing in
+ * the PDF, masking a classification mismatch.
  */
 export function getClassificationMeta(
   level: string,
   customClassifications: CustomClassification[] = [],
 ): ClassificationMeta | null {
+  if (typeof level !== 'string') return null;
+  const trimmed = level.trim();
+  if (!trimmed) return null;
+
   // Custom classifications override built-ins
-  const custom = customClassifications.find((c) => c.id === level);
+  const custom = customClassifications.find((c) => c.id === trimmed);
   if (custom) {
     return {
       level: custom.id,
@@ -84,8 +94,8 @@ export function getClassificationMeta(
   }
 
   // Fall back to built-in taxonomy
-  if (Object.hasOwn(CLASSIFICATION_TAXONOMY, level)) {
-    return CLASSIFICATION_TAXONOMY[level as BuiltinClassificationLevel];
+  if (Object.hasOwn(CLASSIFICATION_TAXONOMY, trimmed)) {
+    return CLASSIFICATION_TAXONOMY[trimmed as BuiltinClassificationLevel];
   }
 
   return null;
@@ -93,12 +103,19 @@ export function getClassificationMeta(
 
 /**
  * Get all known classification IDs (built-in + custom).
+ *
+ * Empty or whitespace-only custom IDs are filtered out so the Default
+ * Classification dropdown never offers a blank choice that, when picked,
+ * would silently disable the banner (no banner = no classification =
+ * compliance leak).
  */
 export function getAllClassificationIds(
   customClassifications: CustomClassification[] = [],
 ): string[] {
   const builtinIds = Object.keys(CLASSIFICATION_TAXONOMY);
-  const customIds = customClassifications.map((c) => c.id);
+  const customIds = customClassifications
+    .map((c) => c.id)
+    .filter((id): id is string => typeof id === 'string' && id.trim() !== '');
   // Custom IDs can shadow built-in ones; deduplicate
   return [...new Set([...builtinIds, ...customIds])];
 }

--- a/src/schemas/classification.ts
+++ b/src/schemas/classification.ts
@@ -80,11 +80,16 @@ export function getClassificationMeta(
   const trimmed = level.trim();
   if (!trimmed) return null;
 
-  // Custom classifications override built-ins
-  const custom = customClassifications.find((c) => c.id === trimmed);
+  // Custom classifications override built-ins. Trim both sides — a stored
+  // custom ID like ' sensitive ' must resolve the same as `sensitive`, and
+  // the returned `level` must be the canonical (trimmed) form so that
+  // downstream class derivation is stable.
+  const custom = customClassifications.find(
+    (c) => typeof c.id === 'string' && c.id.trim() === trimmed,
+  );
   if (custom) {
     return {
-      level: custom.id,
+      level: custom.id.trim(),
       label: custom.label,
       color: custom.color,
       background: custom.background,
@@ -114,8 +119,8 @@ export function getAllClassificationIds(
 ): string[] {
   const builtinIds = Object.keys(CLASSIFICATION_TAXONOMY);
   const customIds = customClassifications
-    .map((c) => c.id)
-    .filter((id): id is string => typeof id === 'string' && id.trim() !== '');
+    .map((c) => (typeof c.id === 'string' ? c.id.trim() : ''))
+    .filter((id) => id !== '');
   // Custom IDs can shadow built-in ones; deduplicate
   return [...new Set([...builtinIds, ...customIds])];
 }

--- a/src/schemas/classification.ts
+++ b/src/schemas/classification.ts
@@ -6,8 +6,14 @@ export type ClassificationLevel = BuiltinClassificationLevel;
 export interface ClassificationMeta {
   level: string;
   label: string;
+  /** Light-theme text color */
   color: string;
+  /** Light-theme background color */
   background: string;
+  /** Dark-theme text color (falls back to `color` when absent) */
+  colorDark?: string;
+  /** Dark-theme background color (falls back to `background` when absent) */
+  backgroundDark?: string;
 }
 
 /** User-defined classification entry */
@@ -16,6 +22,9 @@ export interface CustomClassification {
   label: string;
   color: string;
   background: string;
+  /** Optional dark-theme overrides; reuse light values when absent */
+  colorDark?: string;
+  backgroundDark?: string;
 }
 
 export const CLASSIFICATION_TAXONOMY: Record<BuiltinClassificationLevel, ClassificationMeta> = {
@@ -24,24 +33,32 @@ export const CLASSIFICATION_TAXONOMY: Record<BuiltinClassificationLevel, Classif
     label: 'PUBLIC',
     color: '#2d7d2d',
     background: '#f0faf0',
+    colorDark: '#6cdc6c',
+    backgroundDark: '#1a3a1a',
   },
   internal: {
     level: 'internal',
     label: 'INTERNAL — DO NOT DISTRIBUTE',
     color: '#b8860b',
     background: '#fff8e7',
+    colorDark: '#ffcc66',
+    backgroundDark: '#3a3018',
   },
   confidential: {
     level: 'confidential',
     label: 'CONFIDENTIAL',
     color: '#c41e1e',
     background: '#fff5f5',
+    colorDark: '#ff7777',
+    backgroundDark: '#3a1818',
   },
   restricted: {
     level: 'restricted',
     label: 'RESTRICTED — AUTHORIZED PERSONNEL ONLY',
     color: '#8b0000',
     background: '#ffe0e0',
+    colorDark: '#ff6666',
+    backgroundDark: '#3a0000',
   },
 };
 
@@ -61,6 +78,8 @@ export function getClassificationMeta(
       label: custom.label,
       color: custom.color,
       background: custom.background,
+      colorDark: custom.colorDark,
+      backgroundDark: custom.backgroundDark,
     };
   }
 

--- a/src/schemas/css-bridge.ts
+++ b/src/schemas/css-bridge.ts
@@ -1,3 +1,4 @@
+import { sanitizeCssId } from '../document/css-sanitize';
 import type { DocFrontmatter } from './schema';
 
 type LinksMode = 'expand' | 'styled' | 'plain' | 'stripped' | 'defanged';
@@ -29,14 +30,20 @@ export function resolveLinksMode(pdf: DocFrontmatter['export']['pdf']): LinksMod
 export function deriveCssClasses(frontmatter: DocFrontmatter): string[] {
   const classes: string[] = [];
 
-  // Classification
+  // Classification — sanitize before interpolation so a stray space or
+  // injection character in custom classification IDs can't break out of
+  // the class name and into a selector. classList.add() throws on values
+  // containing whitespace, so an unsanitized push would explode loudly
+  // when these classes are eventually applied.
   if (frontmatter.classification) {
-    classes.push(`pdf-${frontmatter.classification}`);
+    const id = sanitizeCssId(frontmatter.classification);
+    if (id) classes.push(`pdf-${id}`);
   }
 
-  // Status
+  // Status — same sanitization rules as classification
   if (frontmatter.status) {
-    classes.push(`pdf-${frontmatter.status}`);
+    const id = sanitizeCssId(frontmatter.status);
+    if (id) classes.push(`pdf-${id}`);
   }
 
   // Watermark

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export const POS_CATEGORIES: POSCategory[] = [
 /** Per-POS toggle and color settings */
 export interface POSCategorySettings {
   enabled: boolean;
+  /** @deprecated Customize via Style Settings or `--yaae-pos-*-color-{light,dark}` overrides. Read by one-shot migration in POSStyleManager. */
   color: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,12 @@ export interface ProseHighlightSettings {
   readingViewEnabled: boolean;
   /** Custom word lists */
   customWordLists: CustomWordList[];
+  /**
+   * One-shot migration latch for legacy POS color customizations. Once set
+   * to true, the migration in POSStyleManager.init no longer fires, leaving
+   * Style Settings as the sole writer of `--yaae-pos-*-color-{light,dark}`.
+   */
+  posColorsMigrated?: boolean;
 }
 
 /** Default colors matching iA Writer's palette */

--- a/styles.css
+++ b/styles.css
@@ -117,14 +117,12 @@ settings:
     description: Color applied to unfocused text in light theme (defaults to --text-faint)
     type: variable-color
     format: hex
-    default: '#'
   -
     id: yaae-dimmed-color-dark
     title: Dimmed text color (dark)
     description: Color applied to unfocused text in dark theme (defaults to --text-faint)
     type: variable-color
     format: hex
-    default: '#'
   -
     id: yaae-dimmed-transition
     title: Fade transition

--- a/styles.css
+++ b/styles.css
@@ -10,35 +10,77 @@ settings:
     level: 1
     collapsed: true
   -
-    id: yaae-pos-adjective-color
-    title: Adjective color
+    id: yaae-prose-light-heading
+    title: Light theme colors
+    type: heading
+    level: 2
+    collapsed: false
+  -
+    id: yaae-pos-adjective-color-light
+    title: Adjective color (light)
     type: variable-color
     format: hex
     default: '#b97a0a'
   -
-    id: yaae-pos-noun-color
-    title: Noun color
+    id: yaae-pos-noun-color-light
+    title: Noun color (light)
     type: variable-color
     format: hex
     default: '#ce4924'
   -
-    id: yaae-pos-adverb-color
-    title: Adverb color
+    id: yaae-pos-adverb-color-light
+    title: Adverb color (light)
     type: variable-color
     format: hex
     default: '#c333a7'
   -
-    id: yaae-pos-verb-color
-    title: Verb color
+    id: yaae-pos-verb-color-light
+    title: Verb color (light)
     type: variable-color
     format: hex
-    default: '#177eB8'
+    default: '#177eb8'
   -
-    id: yaae-pos-conjunction-color
-    title: Conjunction color
+    id: yaae-pos-conjunction-color-light
+    title: Conjunction color (light)
     type: variable-color
     format: hex
     default: '#01934e'
+  -
+    id: yaae-prose-dark-heading
+    title: Dark theme colors
+    type: heading
+    level: 2
+    collapsed: false
+  -
+    id: yaae-pos-adjective-color-dark
+    title: Adjective color (dark)
+    type: variable-color
+    format: hex
+    default: '#f0b150'
+  -
+    id: yaae-pos-noun-color-dark
+    title: Noun color (dark)
+    type: variable-color
+    format: hex
+    default: '#e87a5f'
+  -
+    id: yaae-pos-adverb-color-dark
+    title: Adverb color (dark)
+    type: variable-color
+    format: hex
+    default: '#e07cc8'
+  -
+    id: yaae-pos-verb-color-dark
+    title: Verb color (dark)
+    type: variable-color
+    format: hex
+    default: '#5cb0e8'
+  -
+    id: yaae-pos-conjunction-color-dark
+    title: Conjunction color (dark)
+    type: variable-color
+    format: hex
+    default: '#4cc887'
   -
     id: yaae-syntax-heading
     title: Syntax Dimming
@@ -70,9 +112,16 @@ settings:
     level: 1
     collapsed: true
   -
-    id: yaae-dimmed-color
-    title: Dimmed text color
-    description: Color applied to unfocused text (defaults to --text-faint)
+    id: yaae-dimmed-color-light
+    title: Dimmed text color (light)
+    description: Color applied to unfocused text in light theme (defaults to --text-faint)
+    type: variable-color
+    format: hex
+    default: '#'
+  -
+    id: yaae-dimmed-color-dark
+    title: Dimmed text color (dark)
+    description: Color applied to unfocused text in dark theme (defaults to --text-faint)
     type: variable-color
     format: hex
     default: '#'
@@ -329,19 +378,22 @@ settings:
    ========================================================================== */
 
 body {
-  /* Prose highlighting — default iA Writer palette */
-  --yaae-pos-adjective-color: #b97a0a;
-  --yaae-pos-noun-color: #ce4924;
-  --yaae-pos-adverb-color: #c333a7;
-  --yaae-pos-verb-color: #177eB8;
-  --yaae-pos-conjunction-color: #01934e;
+  /* Prose highlighting — public variables consumed by feature CSS.
+     Light/dark variants below are the override knobs for Style Settings,
+     theme authors, and snippet authors. The unsuffixed names below are
+     resolved layers — override `--yaae-pos-*-color-{light,dark}` instead. */
+  --yaae-pos-adjective-color: var(--yaae-pos-adjective-color-light, #b97a0a);
+  --yaae-pos-noun-color: var(--yaae-pos-noun-color-light, #ce4924);
+  --yaae-pos-adverb-color: var(--yaae-pos-adverb-color-light, #c333a7);
+  --yaae-pos-verb-color: var(--yaae-pos-verb-color-light, #177eb8);
+  --yaae-pos-conjunction-color: var(--yaae-pos-conjunction-color-light, #01934e);
 
   /* Syntax dimming */
   --yaae-syntax-dimming-opacity: 0.3;
   --yaae-syntax-dimming-active-opacity: 0.7;
 
-  /* Focus mode */
-  --yaae-dimmed-color: var(--text-faint);
+  /* Focus mode — layered, defaults fall through to Obsidian's --text-faint */
+  --yaae-dimmed-color: var(--yaae-dimmed-color-light, var(--text-faint));
   --yaae-dimmed-transition: 0.15s;
 
   /* Guttered headings — rem so the gutter doesn't scale with heading font sizes */
@@ -394,6 +446,18 @@ body {
   --yaae-print-orphans: 3;
 }
 
+/* Dark-theme overrides for editor-side colors. Theme authors can override
+   any --yaae-pos-*-color-dark or --yaae-dimmed-color-dark to recolor for
+   their dark theme without fighting plugin specificity. */
+body.theme-dark {
+  --yaae-pos-adjective-color: var(--yaae-pos-adjective-color-dark, #f0b150);
+  --yaae-pos-noun-color: var(--yaae-pos-noun-color-dark, #e87a5f);
+  --yaae-pos-adverb-color: var(--yaae-pos-adverb-color-dark, #e07cc8);
+  --yaae-pos-verb-color: var(--yaae-pos-verb-color-dark, #5cb0e8);
+  --yaae-pos-conjunction-color: var(--yaae-pos-conjunction-color-dark, #4cc887);
+  --yaae-dimmed-color: var(--yaae-dimmed-color-dark, var(--text-faint));
+}
+
 /* ==========================================================================
    Prose Highlighting — POS category and custom list class rules
    ========================================================================== */
@@ -403,6 +467,26 @@ body {
 .yaae-pos-adverb { color: var(--yaae-pos-adverb-color); }
 .yaae-pos-verb { color: var(--yaae-pos-verb-color); }
 .yaae-pos-conjunction { color: var(--yaae-pos-conjunction-color); }
+
+/* ==========================================================================
+   Classification Banner — reading view
+   Banner element carries `--yaae-banner-{color,bg}` and optional `-dark`
+   variants as inline custom properties. The rules below switch which pair
+   is used based on the active theme. Theme/snippet authors can override
+   these on `.yaae-classification-banner` directly.
+   ========================================================================== */
+
+.yaae-classification-banner {
+  background: var(--yaae-banner-bg);
+  color: var(--yaae-banner-color);
+  border: 1px solid var(--yaae-banner-color);
+}
+
+body.theme-dark .yaae-classification-banner {
+  background: var(--yaae-banner-bg-dark, var(--yaae-banner-bg));
+  color: var(--yaae-banner-color-dark, var(--yaae-banner-color));
+  border-color: var(--yaae-banner-color-dark, var(--yaae-banner-color));
+}
 
 /* ===== Print / PDF Export Suppression =====
  * Hide all prose highlighting decorations when printing or exporting to PDF.

--- a/test-vault/.obsidian/plugins/yaae/manifest.json
+++ b/test-vault/.obsidian/plugins/yaae/manifest.json
@@ -1,1 +1,1 @@
-/Users/cameron/Projects/yaae/manifest.json
+../../../../manifest.json

--- a/test-vault/.obsidian/plugins/yaae/manifest.json
+++ b/test-vault/.obsidian/plugins/yaae/manifest.json
@@ -1,1 +1,1 @@
-/Users/cameron/Projects/yaae-test-vault-audit/manifest.json
+/Users/cameron/Projects/yaae/manifest.json

--- a/test-vault/.obsidian/plugins/yaae/styles.css
+++ b/test-vault/.obsidian/plugins/yaae/styles.css
@@ -1,1 +1,1 @@
-/Users/cameron/Projects/yaae-test-vault-audit/styles.css
+/Users/cameron/Projects/yaae/styles.css

--- a/test-vault/.obsidian/plugins/yaae/styles.css
+++ b/test-vault/.obsidian/plugins/yaae/styles.css
@@ -1,1 +1,1 @@
-/Users/cameron/Projects/yaae/styles.css
+../../../../styles.css

--- a/tests/classification-banner.test.ts
+++ b/tests/classification-banner.test.ts
@@ -66,8 +66,16 @@ describe('classificationBannerProcessor', () => {
       const meta = CLASSIFICATION_TAXONOMY[level];
       expect(banner.className).toContain(`yaae-${level}`);
       expect(banner.textContent).toBe(meta.label);
-      expect(banner.style.cssText).toContain(`background: ${meta.background}`);
-      expect(banner.style.cssText).toContain(`color: ${meta.color}`);
+      // Colors flow through CSS custom properties so styles.css can swap on body.theme-dark
+      expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-color', meta.color);
+      expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-bg', meta.background);
+      // Built-ins now carry dark variants too
+      if (meta.colorDark) {
+        expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-color-dark', meta.colorDark);
+      }
+      if (meta.backgroundDark) {
+        expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-bg-dark', meta.backgroundDark);
+      }
     }
   });
 
@@ -158,8 +166,8 @@ describe('classificationBannerProcessor — custom classifications', () => {
     const banner = (el.insertBefore as any).mock.calls[0][0];
     expect(banner.className).toBe('yaae-classification-banner yaae-non-sensitive');
     expect(banner.textContent).toBe('NON-SENSITIVE');
-    expect(banner.style.cssText).toContain('color: #2d7d2d');
-    expect(banner.style.cssText).toContain('background: #f0faf0');
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-color', '#2d7d2d');
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-bg', '#f0faf0');
   });
 
   it('injects banner for all custom levels', () => {
@@ -184,5 +192,42 @@ describe('classificationBannerProcessor — custom classifications', () => {
     expect(el.insertBefore).toHaveBeenCalledOnce();
     const banner = (el.insertBefore as any).mock.calls[0][0];
     expect(banner.textContent).toBe(CLASSIFICATION_TAXONOMY.internal.label);
+  });
+
+  it('propagates dark-theme overrides from custom classification', () => {
+    const customWithDark: CustomClassification = {
+      id: 'tinted',
+      label: 'TINTED',
+      color: '#444444',
+      background: '#eeeeee',
+      colorDark: '#cccccc',
+      backgroundDark: '#222222',
+    };
+    const darkProcessor = createClassificationBannerProcessor(settingsGetter({
+      customClassifications: [customWithDark],
+    }));
+
+    const el = makeEl();
+    const ctx = makeCtx({ lineStart: 0, frontmatter: { classification: 'tinted' } });
+
+    darkProcessor(el, ctx);
+
+    const banner = (el.insertBefore as any).mock.calls[0][0];
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-color', '#444444');
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-bg', '#eeeeee');
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-color-dark', '#cccccc');
+    expect(banner.style.setProperty).toHaveBeenCalledWith('--yaae-banner-bg-dark', '#222222');
+  });
+
+  it('omits dark variant setProperty calls when colorDark/backgroundDark absent', () => {
+    const el = makeEl();
+    const ctx = makeCtx({ lineStart: 0, frontmatter: { classification: 'non-sensitive' } });
+
+    processor(el, ctx);
+
+    const banner = (el.insertBefore as any).mock.calls[0][0];
+    const setPropCalls = (banner.style.setProperty as any).mock.calls.map((c: unknown[]) => c[0]);
+    expect(setPropCalls).not.toContain('--yaae-banner-color-dark');
+    expect(setPropCalls).not.toContain('--yaae-banner-bg-dark');
   });
 });

--- a/tests/classification-banner.test.ts
+++ b/tests/classification-banner.test.ts
@@ -231,3 +231,97 @@ describe('classificationBannerProcessor — custom classifications', () => {
     expect(setPropCalls).not.toContain('--yaae-banner-bg-dark');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression coverage: classification-correctness fixes
+// ---------------------------------------------------------------------------
+
+describe('classificationBannerProcessor — F1: custom property survival', () => {
+  // Defends against the `cssText +=` regression: when layout was assigned
+  // via cssText round-trip, Chromium could clobber the four
+  // --yaae-banner-* declarations set immediately before. Verify all four
+  // setProperty calls remain on the banner element after layout is applied.
+  const customWithDark: CustomClassification = {
+    id: 'tinted',
+    label: 'TINTED',
+    color: '#444444',
+    background: '#eeeeee',
+    colorDark: '#cccccc',
+    backgroundDark: '#222222',
+  };
+  const processor = createClassificationBannerProcessor(settingsGetter({
+    customClassifications: [customWithDark],
+  }));
+
+  it('preserves all four --yaae-banner-* custom properties through layout assignment', () => {
+    const el = makeEl();
+    const ctx = makeCtx({ lineStart: 0, frontmatter: { classification: 'tinted' } });
+
+    processor(el, ctx);
+
+    const banner = (el.insertBefore as any).mock.calls[0][0];
+    const setPropCalls = (banner.style.setProperty as any).mock.calls;
+    const setPropMap = new Map<string, string>();
+    for (const [prop, value] of setPropCalls) {
+      setPropMap.set(prop, value);
+    }
+
+    // All four custom properties must still be declared on the element
+    // after the layout block runs.
+    expect(setPropMap.get('--yaae-banner-color')).toBe('#444444');
+    expect(setPropMap.get('--yaae-banner-bg')).toBe('#eeeeee');
+    expect(setPropMap.get('--yaae-banner-color-dark')).toBe('#cccccc');
+    expect(setPropMap.get('--yaae-banner-bg-dark')).toBe('#222222');
+
+    // Layout properties also flow through setProperty (no cssText += round-trip)
+    expect(setPropMap.has('text-align')).toBe(true);
+    expect(setPropMap.has('padding')).toBe(true);
+  });
+});
+
+describe('classificationBannerProcessor — F2/F3: class-name and whitespace handling', () => {
+  it('builds usable class string when classification has surrounding whitespace', () => {
+    // F3: whitespace classification mismatch. Banner should resolve and use
+    // the trimmed level, not the raw frontmatter value with spaces.
+    const processor = createClassificationBannerProcessor(settingsGetter());
+    const el = makeEl();
+    const ctx = makeCtx({ lineStart: 0, frontmatter: { classification: '  internal  ' } });
+
+    processor(el, ctx);
+
+    expect(el.insertBefore).toHaveBeenCalledOnce();
+    const banner = (el.insertBefore as any).mock.calls[0][0];
+    // Class fragment is sanitized — no leading/trailing spaces leaked into the className
+    expect(banner.className).toBe('yaae-classification-banner yaae-internal');
+    // setProperty values still match the resolved built-in
+    const setPropCalls = (banner.style.setProperty as any).mock.calls;
+    const setPropMap = new Map<string, string>(setPropCalls.map((c: unknown[]) => [c[0] as string, c[1] as string]));
+    expect(setPropMap.get('--yaae-banner-color')).toBe(CLASSIFICATION_TAXONOMY.internal.color);
+  });
+
+  it('sanitizes custom classification IDs that contain spaces', () => {
+    // F2: ensure stray spaces in a custom classification ID don't split into
+    // multiple class tokens or cause a selector-injection style breakout.
+    // The custom classification "internal extra" is invalid by sanitizeCssId
+    // rules — the banner should still render but skip the classFragment.
+    const malformed: CustomClassification = {
+      id: 'internal extra',
+      label: 'MALFORMED',
+      color: '#444444',
+      background: '#eeeeee',
+    };
+    const processor = createClassificationBannerProcessor(settingsGetter({
+      customClassifications: [malformed],
+    }));
+    const el = makeEl();
+    const ctx = makeCtx({ lineStart: 0, frontmatter: { classification: 'internal extra' } });
+
+    processor(el, ctx);
+
+    expect(el.insertBefore).toHaveBeenCalledOnce();
+    const banner = (el.insertBefore as any).mock.calls[0][0];
+    // No second yaae-* class fragment leaked through
+    expect(banner.className).toBe('yaae-classification-banner');
+    expect(banner.textContent).toBe('MALFORMED');
+  });
+});

--- a/tests/css-sanitize.test.ts
+++ b/tests/css-sanitize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   escapeCssString,
   sanitizeColor,
@@ -67,6 +67,41 @@ describe('sanitizeColor', () => {
 
   it('rejects empty string', () => {
     expect(sanitizeColor('', '#000')).toBe('#000');
+  });
+
+  // F5: silent fallback used to disguise corrupt classification colors as
+  // black-on-white, visually similar to the PUBLIC banner. Warn on
+  // rejection so misclassification doesn't ship to PDF unnoticed.
+  describe('warns on invalid input (F5)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns when input is not a hex color', () => {
+      sanitizeColor('rgb(255,0,0)', '#000');
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain('[yaae]');
+      expect(warnSpy.mock.calls[0][1]).toBe('rgb(255,0,0)');
+    });
+
+    it('warns on injection attempt', () => {
+      sanitizeColor('red; content: "pwned"; color', '#000');
+      expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it('warns on empty string', () => {
+      sanitizeColor('', '#000');
+      expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not warn on valid hex color', () => {
+      sanitizeColor('#c41e1e', '#000');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/tests/css-structure.test.ts
+++ b/tests/css-structure.test.ts
@@ -54,6 +54,20 @@ describe('styles.css — focus mode', () => {
     expect(STYLES_CSS).toMatch(/\.yaae-dimmed\s*\{[^}]*color/s);
     expect(STYLES_CSS).toMatch(/\.yaae-dimmed\s*\{[^}]*transition/s);
   });
+
+  // F4: `default: '#'` is an invalid hex color. If Style Settings persists
+  // it as the variable's value, the var() fallback to --text-faint is
+  // suppressed (the variable has a non-empty value), so the dimmed text
+  // resolves to an invalid color and disappears. The @settings YAML must
+  // omit the default key so Style Settings leaves the variable unset.
+  it("@settings YAML has no `default: '#'` entries (would inject invalid hex)", () => {
+    expect(STYLES_CSS).not.toMatch(/default:\s*['"]#['"]/);
+  });
+
+  it('dimmed-color variables fall back to --text-faint when unset', () => {
+    expect(STYLES_CSS).toContain('var(--yaae-dimmed-color-light, var(--text-faint))');
+    expect(STYLES_CSS).toContain('var(--yaae-dimmed-color-dark, var(--text-faint))');
+  });
 });
 
 describe('styles.css — print media', () => {

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -191,3 +191,35 @@ describe('F8 — loadSettings resets non-array customClassifications to []', () 
     expect(document.customClassifications).toBe(value);
   });
 });
+
+// --- F9: cssclasses filter is type-safe -----------------------------------
+
+describe('F9 — cssclasses filter rejects non-string entries safely', () => {
+  it('filter callback uses a typeof string guard', () => {
+    expect(MAIN_TS).toMatch(/typeof\s+c\s*===\s*'string'\s*&&\s*!c\.startsWith\(\s*'pdf-'\s*\)/);
+  });
+
+  // Behavioral reproduction of the filter logic.
+  function filterUserCssClasses(input: unknown[]): string[] {
+    return input.filter(
+      (c): c is string => typeof c === 'string' && !c.startsWith('pdf-'),
+    );
+  }
+
+  it('does not throw on numeric entries', () => {
+    expect(() => filterUserCssClasses([1, 'pdf-foo', 'user-class'])).not.toThrow();
+  });
+
+  it('drops non-strings and pdf-* entries, keeps user classes', () => {
+    expect(filterUserCssClasses([1, null, 'pdf-internal', 'theme-dark', 'pdf-foo']))
+      .toEqual(['theme-dark']);
+  });
+
+  it('handles empty input', () => {
+    expect(filterUserCssClasses([])).toEqual([]);
+  });
+
+  it('handles mixed undefined / boolean entries', () => {
+    expect(filterUserCssClasses([undefined, true, false, 'keep'])).toEqual(['keep']);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -34,3 +34,27 @@ describe('F1 — export.pdf.theme propagates to PageChromeManager', () => {
     expect(printStyles).toMatch(/theme\?:\s*'light'\s*\|\s*'dark'\s*\|\s*'auto'/);
   });
 });
+
+// --- F2: validateOnSave toggle is reactive --------------------------------
+
+describe('F2 — validateOnSave toggle takes effect without reload', () => {
+  it('does not gate the modify handler on startup setting value', () => {
+    // The buggy form was: if (this.settings.document.validateOnSave) { registerEvent(...) }
+    // The fix gates *inside* the handler. So the registerEvent(vault.on('modify', ...))
+    // should not be wrapped in an outer if (this.settings.document.validateOnSave).
+    const validateBlock = MAIN_TS.match(
+      /\/\/ Validate on save[\s\S]*?this\.registerEvent\([\s\S]*?\)\s*\)\s*;/,
+    );
+    expect(validateBlock).not.toBeNull();
+    const block = validateBlock![0];
+    expect(block).not.toMatch(
+      /if\s*\(\s*this\.settings\.document\.validateOnSave\s*\)\s*\{[\s\S]*?this\.registerEvent/,
+    );
+  });
+
+  it('checks validateOnSave inside the modify handler at runtime', () => {
+    expect(MAIN_TS).toMatch(
+      /this\.app\.vault\.on\(\s*'modify'[\s\S]*?if\s*\(\s*!this\.settings\.document\.validateOnSave\s*\)\s*return/,
+    );
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -223,3 +223,14 @@ describe('F9 — cssclasses filter rejects non-string entries safely', () => {
     expect(filterUserCssClasses([undefined, true, false, 'keep'])).toEqual(['keep']);
   });
 });
+
+// --- F10: settings tab uses registerDomEvent ------------------------------
+
+describe('F10 — settings tab nav buttons use registerDomEvent', () => {
+  it('does not use raw addEventListener for tab nav buttons', () => {
+    const cls = MAIN_TS.match(/class\s+YaaeSettingTab[\s\S]*$/);
+    expect(cls).not.toBeNull();
+    expect(cls![0]).toMatch(/this\.registerDomEvent\(\s*btn\s*,\s*'click'/);
+    expect(cls![0]).not.toMatch(/btn\.addEventListener\(\s*'click'/);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -92,3 +92,35 @@ describe('F4 — generateTocForCurrentFile is race-safe', () => {
     expect(MAIN_TS).toMatch(/console\.debug\([^)]*TOC abort/);
   });
 });
+
+// --- F5: bootstrap on layout ready ----------------------------------------
+
+describe('F5 — page chrome bootstraps from active file on startup', () => {
+  it('calls updatePageChromeFromActiveFile from onLayoutReady', () => {
+    expect(MAIN_TS).toMatch(
+      /onLayoutReady\(\s*\(\)\s*=>\s*\{[\s\S]*?this\.updatePageChromeFromActiveFile\(\)/,
+    );
+  });
+});
+
+// --- F6: non-markdown active leaf does not clobber chrome ----------------
+
+describe('F6 — non-markdown active leaf preserves last markdown chrome', () => {
+  it('returns early without updating chrome for non-md files', () => {
+    // After the startFile null/extension check, when extension !== 'md',
+    // we must NOT call pageChromeManager.update — we just `return`.
+    const fn = MAIN_TS.match(
+      /async\s+updatePageChromeFromActiveFile\s*\(\s*\)\s*:\s*Promise<void>\s*\{[\s\S]*?\n\s{2}\}/,
+    );
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+
+    const nonMdBranch = body.match(
+      /if\s*\(\s*startFile\.extension\s*!==\s*'md'\s*\)\s*\{[\s\S]*?\}/,
+    );
+    expect(nonMdBranch).not.toBeNull();
+    const branchBody = nonMdBranch![0];
+    expect(branchBody).not.toMatch(/pageChromeManager\.update/);
+    expect(branchBody).toMatch(/return/);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -291,3 +291,17 @@ describe('F11 — yaae-generate-toc respects checking flag', () => {
     expect(workFired).toBe(0);
   });
 });
+
+// --- F12: deferred saveSettings during loadSettings migration -------------
+
+describe('F12 — saveSettings during migration is deferred', () => {
+  it('migration uses queueMicrotask instead of inline await saveSettings', () => {
+    const block = MAIN_TS.match(
+      /Migrate deprecated expandLinks\/plainLinks[\s\S]*?\n\s{2}\}/,
+    );
+    expect(block).not.toBeNull();
+    expect(block![0]).toMatch(/queueMicrotask\(\s*\(\)\s*=>\s*\{/);
+    // The bare `await this.saveSettings();` form should be gone from this block.
+    expect(block![0]).not.toMatch(/^\s*await\s+this\.saveSettings\(\);\s*$/m);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -58,3 +58,37 @@ describe('F2 — validateOnSave toggle takes effect without reload', () => {
     );
   });
 });
+
+// --- F3: race in updatePageChromeFromActiveFile ---------------------------
+
+describe('F3 — updatePageChromeFromActiveFile is race-safe', () => {
+  it('captures startFile before vault.read', () => {
+    expect(MAIN_TS).toMatch(/const\s+startFile\s*=\s*this\.app\.workspace\.getActiveFile\(\)/);
+  });
+
+  it('re-checks getActiveFile() after vault.read and bails if changed', () => {
+    expect(MAIN_TS).toMatch(
+      /await\s+this\.app\.vault\.read\(startFile\)[\s\S]*?if\s*\(\s*this\.app\.workspace\.getActiveFile\(\)\s*!==\s*startFile\s*\)[\s\S]*?return/,
+    );
+  });
+});
+
+// --- F4: race in generateTocForCurrentFile --------------------------------
+
+describe('F4 — generateTocForCurrentFile is race-safe', () => {
+  it('re-checks active file after vault.read and bails before vault.modify', () => {
+    const tocFn = MAIN_TS.match(/async\s+generateTocForCurrentFile\s*\(\s*\)[\s\S]*?\n\s{2}\}/);
+    expect(tocFn).not.toBeNull();
+    const body = tocFn![0];
+    const readIdx = body.indexOf('vault.read(file)');
+    const guardIdx = body.search(/this\.app\.workspace\.getActiveFile\(\)\s*!==\s*file/);
+    const modifyIdx = body.indexOf('vault.modify(file');
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeGreaterThan(readIdx);
+    expect(modifyIdx).toBeGreaterThan(guardIdx);
+  });
+
+  it('emits a debug message when aborting due to race', () => {
+    expect(MAIN_TS).toMatch(/console\.debug\([^)]*TOC abort/);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -124,3 +124,27 @@ describe('F6 — non-markdown active leaf preserves last markdown chrome', () =>
     expect(branchBody).toMatch(/return/);
   });
 });
+
+// --- F7: TFile type guards -----------------------------------------------
+
+describe('F7 — vault.read call sites guard with TFile instanceof', () => {
+  it('validateCurrentFile checks instanceof TFile', () => {
+    const fn = MAIN_TS.match(/async\s+validateCurrentFile\s*\(\s*\)\s*\{[\s\S]*?\n\s{2}\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/if\s*\(\s*!\(\s*file\s+instanceof\s+TFile\s*\)\s*\)\s*return/);
+  });
+
+  it('generateTocForCurrentFile checks instanceof TFile', () => {
+    const fn = MAIN_TS.match(/async\s+generateTocForCurrentFile\s*\(\s*\)\s*\{[\s\S]*?\n\s{2}\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/if\s*\(\s*!\(\s*file\s+instanceof\s+TFile\s*\)\s*\)\s*return/);
+  });
+
+  it('applyCssClassesFromFrontmatter checks instanceof TFile', () => {
+    const fn = MAIN_TS.match(
+      /async\s+applyCssClassesFromFrontmatter\s*\(\s*\)\s*\{[\s\S]*?\n\s{2}\}/,
+    );
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/if\s*\(\s*!\(\s*file\s+instanceof\s+TFile\s*\)\s*\)\s*return/);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -34,8 +34,9 @@ describe('F1 — export.pdf.theme propagates to PageChromeManager', () => {
     // Field is required — consumed by PageChromeManager.update for the
     // auto-theme branch. Per-document `export.pdf.theme` frontmatter
     // overrides still propagate; main.ts spreads the override on top of
-    // the global default from buildPageChromeState.
-    expect(printStyles).toMatch(/theme:\s*'light'\s*\|\s*'dark'\s*\|\s*'auto'/);
+    // the global default from buildPageChromeState. Type aliased to
+    // ThemeMode (imported from ./settings) so the union lives in one place.
+    expect(printStyles).toMatch(/theme:\s*ThemeMode/);
   });
 });
 

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -234,3 +234,60 @@ describe('F10 — settings tab nav buttons use registerDomEvent', () => {
     expect(cls![0]).not.toMatch(/btn\.addEventListener\(\s*'click'/);
   });
 });
+
+// --- F11: editorCheckCallback honors the checking flag --------------------
+
+describe('F11 — yaae-generate-toc respects checking flag', () => {
+  it('only invokes generateTocForCurrentFile when not checking', () => {
+    const cmdBlock = MAIN_TS.match(/id:\s*'yaae-generate-toc'[\s\S]*?\}\)\s*;/);
+    expect(cmdBlock).not.toBeNull();
+    expect(cmdBlock![0]).toMatch(/if\s*\(\s*!checking\s*\)\s*this\.generateTocForCurrentFile\(\)/);
+    expect(cmdBlock![0]).toMatch(/!file\s*\|\|\s*file\.extension\s*!==\s*'md'/);
+  });
+
+  // Behavioral simulation of the command's check/exec phases.
+  it('checking=true returns true without firing work', () => {
+    let workFired = 0;
+    const fakeCommand = {
+      editorCheckCallback: (checking: boolean) => {
+        const file = { extension: 'md' };
+        if (!file || file.extension !== 'md') return false;
+        if (!checking) workFired++;
+        return true;
+      },
+    };
+    const result = fakeCommand.editorCheckCallback(true);
+    expect(result).toBe(true);
+    expect(workFired).toBe(0);
+  });
+
+  it('checking=false fires the work', () => {
+    let workFired = 0;
+    const fakeCommand = {
+      editorCheckCallback: (checking: boolean) => {
+        const file = { extension: 'md' };
+        if (!file || file.extension !== 'md') return false;
+        if (!checking) workFired++;
+        return true;
+      },
+    };
+    const result = fakeCommand.editorCheckCallback(false);
+    expect(result).toBe(true);
+    expect(workFired).toBe(1);
+  });
+
+  it('returns false (and does no work) for non-md files even when checking=false', () => {
+    let workFired = 0;
+    const fakeCommand = {
+      editorCheckCallback: (checking: boolean) => {
+        const file = { extension: 'pdf' };
+        if (!file || file.extension !== 'md') return false;
+        if (!checking) workFired++;
+        return true;
+      },
+    };
+    const result = fakeCommand.editorCheckCallback(false);
+    expect(result).toBe(false);
+    expect(workFired).toBe(0);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Lifecycle / wiring regression tests for main.ts.
+ *
+ * main.ts pulls in CM6 imports that need browser DOM globals, so we test
+ * the source structurally (text inspection) for wiring guarantees and
+ * verify the data-shape behaviors via small isolated reproductions.
+ *
+ * Each block maps to a finding F1..F12 from the bug hunt.
+ */
+
+const MAIN_TS = readFileSync(join(__dirname, '..', 'main.ts'), 'utf-8');
+
+// --- F1: theme propagation ------------------------------------------------
+
+describe('F1 — export.pdf.theme propagates to PageChromeManager', () => {
+  it('updatePageChromeFromActiveFile reads theme from frontmatter', () => {
+    expect(MAIN_TS).toMatch(/result\.data\?\.export\?\.pdf\?\.theme/);
+  });
+
+  it('passes theme through to pageChromeManager.update when present', () => {
+    // Spread pattern: ...(theme ? { theme } : {})
+    expect(MAIN_TS).toMatch(/\.\.\.\(theme\s*\?\s*\{\s*theme\s*\}\s*:\s*\{\}\)/);
+  });
+
+  it('PageChromeState interface includes optional theme field', () => {
+    const printStyles = readFileSync(
+      join(__dirname, '..', 'src', 'document', 'print-styles.ts'),
+      'utf-8',
+    );
+    expect(printStyles).toMatch(/theme\?:\s*'light'\s*\|\s*'dark'\s*\|\s*'auto'/);
+  });
+});

--- a/tests/main-lifecycle.test.ts
+++ b/tests/main-lifecycle.test.ts
@@ -148,3 +148,46 @@ describe('F7 — vault.read call sites guard with TFile instanceof', () => {
     expect(fn![0]).toMatch(/if\s*\(\s*!\(\s*file\s+instanceof\s+TFile\s*\)\s*\)\s*return/);
   });
 });
+
+// --- F8: customClassifications resilience ---------------------------------
+
+describe('F8 — loadSettings resets non-array customClassifications to []', () => {
+  it('contains an Array.isArray guard for customClassifications', () => {
+    expect(MAIN_TS).toMatch(
+      /Array\.isArray\(\s*this\.settings\.document\.customClassifications\s*\)/,
+    );
+  });
+
+  it('resets to [] when not an array', () => {
+    expect(MAIN_TS).toMatch(
+      /!Array\.isArray\(\s*this\.settings\.document\.customClassifications\s*\)[\s\S]*?this\.settings\.document\.customClassifications\s*=\s*\[\]/,
+    );
+  });
+
+  // Behavioral test of the guard logic, copy-pasted from main.ts to avoid
+  // importing the plugin (which pulls in CM6 / browser-only modules).
+  it('guard logic resets null to []', () => {
+    const document: { customClassifications: unknown } = { customClassifications: null };
+    if (!Array.isArray(document.customClassifications)) {
+      document.customClassifications = [];
+    }
+    expect(document.customClassifications).toEqual([]);
+  });
+
+  it('guard logic resets a string to []', () => {
+    const document: { customClassifications: unknown } = { customClassifications: 'corrupt' };
+    if (!Array.isArray(document.customClassifications)) {
+      document.customClassifications = [];
+    }
+    expect(document.customClassifications).toEqual([]);
+  });
+
+  it('guard logic preserves a valid non-empty array', () => {
+    const value = [{ id: 'tlp-red', label: 'TLP:RED', color: '#f00', background: '#000' }];
+    const document: { customClassifications: unknown } = { customClassifications: value };
+    if (!Array.isArray(document.customClassifications)) {
+      document.customClassifications = [];
+    }
+    expect(document.customClassifications).toBe(value);
+  });
+});

--- a/tests/pos-styles.test.ts
+++ b/tests/pos-styles.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POSStyleManager } from '../src/prose-highlight/pos-styles';
-import { DEFAULT_PROSE_HIGHLIGHT_SETTINGS } from '../src/types';
+import { DEFAULT_PROSE_HIGHLIGHT_SETTINGS, DEFAULT_POS_COLORS } from '../src/types';
 import type { ProseHighlightSettings } from '../src/types';
 
-// Mock document.head and createElement for Node.js environment
+/**
+ * POSStyleManager owns custom word list <style> injection AND a one-shot
+ * migration that writes legacy POS colors to body.style.setProperty().
+ * POS color defaults themselves live in styles.css (--yaae-pos-*-color-{light,dark}).
+ */
 function setupDOM() {
   const styleEl = {
     id: '',
@@ -12,14 +16,20 @@ function setupDOM() {
   };
 
   const headAppendChild = vi.fn();
+  const bodySetProperty = vi.fn();
   (globalThis as any).document = {
     createElement: vi.fn(() => styleEl),
     head: {
       appendChild: headAppendChild,
     },
+    body: {
+      style: {
+        setProperty: bodySetProperty,
+      },
+    },
   };
 
-  return { styleEl, headAppendChild };
+  return { styleEl, headAppendChild, bodySetProperty };
 }
 
 describe('POSStyleManager', () => {
@@ -35,30 +45,12 @@ describe('POSStyleManager', () => {
     manager.destroy();
   });
 
-  // --- Happy paths ---
+  // --- Style element lifecycle ---
 
   it('should create a <style> element on init', () => {
     manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
     expect(document.createElement).toHaveBeenCalledWith('style');
     expect(dom.headAppendChild).toHaveBeenCalled();
-  });
-
-  it('should set CSS custom properties for all POS categories', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
-    const css = dom.styleEl.textContent;
-
-    expect(css).toContain('--yaae-pos-adjective-color');
-    expect(css).toContain('--yaae-pos-noun-color');
-    expect(css).toContain('--yaae-pos-adverb-color');
-    expect(css).toContain('--yaae-pos-verb-color');
-    expect(css).toContain('--yaae-pos-conjunction-color');
-  });
-
-  it('should wrap POS variables in a body {} block', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
-    const css = dom.styleEl.textContent;
-
-    expect(css).toMatch(/^body \{.*--yaae-pos-.*\}$/m);
   });
 
   it('should not emit .yaae-pos-* class selectors (static in styles.css)', () => {
@@ -69,35 +61,62 @@ describe('POSStyleManager', () => {
     expect(css).not.toContain('.yaae-pos-noun');
   });
 
-  it('should use default iA Writer colors', () => {
+  it('should not emit POS variable rules into <style> (defaults live in styles.css)', () => {
     manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
     const css = dom.styleEl.textContent;
 
-    expect(css).toContain('#b97a0a'); // adjective
-    expect(css).toContain('#ce4924'); // noun
-    expect(css).toContain('#c333a7'); // adverb
-    expect(css).toContain('#177eB8'); // verb
-    expect(css).toContain('#01934e'); // conjunction
+    expect(css).not.toContain('--yaae-pos-adjective-color');
+    expect(css).not.toContain('body {');
   });
 
-  it('should update CSS variables when colors change', () => {
+  it('should emit empty <style> textContent when no custom word lists exist', () => {
     manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    expect(dom.styleEl.textContent).toBe('');
+  });
 
-    const newSettings: ProseHighlightSettings = {
+  it('should remove <style> element on destroy', () => {
+    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.destroy();
+    expect(dom.styleEl.remove).toHaveBeenCalled();
+  });
+
+  // --- Migration (legacy POS color → body.style --yaae-pos-*-color-light) ---
+
+  it('should not migrate when POS colors match defaults', () => {
+    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    expect(dom.bodySetProperty).not.toHaveBeenCalled();
+  });
+
+  it('should migrate non-default POS color to --yaae-pos-*-color-light on body', () => {
+    const customized: ProseHighlightSettings = {
       ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
       categories: {
         ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories,
         adjective: { enabled: true, color: '#ff0000' },
       },
     };
-
-    manager.update(newSettings);
-    const css = dom.styleEl.textContent;
-
-    expect(css).toContain('--yaae-pos-adjective-color: #ff0000;');
-    // Other categories unchanged
-    expect(css).toContain('--yaae-pos-noun-color: #ce4924;');
+    manager.init(customized);
+    expect(dom.bodySetProperty).toHaveBeenCalledWith('--yaae-pos-adjective-color-light', '#ff0000');
   });
+
+  it('should migrate multiple non-default POS colors', () => {
+    const customized: ProseHighlightSettings = {
+      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      categories: {
+        adjective: { enabled: true, color: '#ff0000' },
+        noun: { enabled: true, color: '#00ff00' },
+        adverb: { enabled: true, color: DEFAULT_POS_COLORS.adverb },
+        verb: { enabled: true, color: DEFAULT_POS_COLORS.verb },
+        conjunction: { enabled: true, color: DEFAULT_POS_COLORS.conjunction },
+      },
+    };
+    manager.init(customized);
+    expect(dom.bodySetProperty).toHaveBeenCalledWith('--yaae-pos-adjective-color-light', '#ff0000');
+    expect(dom.bodySetProperty).toHaveBeenCalledWith('--yaae-pos-noun-color-light', '#00ff00');
+    expect(dom.bodySetProperty).toHaveBeenCalledTimes(2);
+  });
+
+  // --- Custom word list rules ---
 
   it('should include custom word list CSS rules as direct class selectors', () => {
     const settings: ProseHighlightSettings = {
@@ -138,12 +157,6 @@ describe('POSStyleManager', () => {
     expect(css).toContain('#bbb');
   });
 
-  it('should remove <style> element on destroy', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
-    manager.destroy();
-    expect(dom.styleEl.remove).toHaveBeenCalled();
-  });
-
   it('update() should replace old list rules with new ones', () => {
     manager.init({
       ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
@@ -160,9 +173,6 @@ describe('POSStyleManager', () => {
     });
     const css = dom.styleEl.textContent;
 
-    // POS variables still present
-    expect(css).toContain('--yaae-pos-adjective-color');
-    // Old list gone, new list present
     expect(css).not.toContain('.yaae-list-old');
     expect(css).toContain('.yaae-list-new');
     expect(css).toContain('#222');
@@ -171,12 +181,9 @@ describe('POSStyleManager', () => {
   // --- Unhappy paths ---
 
   it('update() before init() should be a no-op', () => {
-    // No init called — styleEl is null
     manager.update(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
-    // Should not throw, style element should be untouched
     expect(dom.styleEl.textContent).toBe('');
   });
-
 
   it('destroy() before init() should not throw', () => {
     expect(() => manager.destroy()).not.toThrow();
@@ -218,23 +225,9 @@ describe('POSStyleManager', () => {
     expect(css).not.toContain('#abc');
   });
 
-  it('should still emit POS variables when word lists are empty', () => {
-    const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
-      customWordLists: [],
-    };
-
-    manager.init(settings);
-    const css = dom.styleEl.textContent;
-
-    expect(css).toContain('--yaae-pos-adjective-color');
-    expect(css).not.toContain('.yaae-list-');
-  });
-
   it('update() after destroy() should be a no-op', () => {
     manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
     manager.destroy();
-    // Should not throw even though styleEl is now null
     expect(() => manager.update(DEFAULT_PROSE_HIGHLIGHT_SETTINGS)).not.toThrow();
   });
 });

--- a/tests/pos-styles.test.ts
+++ b/tests/pos-styles.test.ts
@@ -298,4 +298,19 @@ describe('POSStyleManager', () => {
     manager.destroy();
     expect(() => manager.update(freshDefaults())).not.toThrow();
   });
+
+  // --- F5: Idempotent init (no orphan <style> on double-init) ---
+
+  it('init() called twice removes the first <style> element before creating the second', () => {
+    manager.init(freshDefaults());
+    const firstEl = dom.styleEl;
+    const firstRemove = firstEl.remove;
+
+    // Second init must destroy the prior element so it does not orphan
+    manager.init(freshDefaults());
+
+    expect(firstRemove).toHaveBeenCalled();
+    // setupDOM() reuses the same mock for createElement; called once per init()
+    expect(document.createElement).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/pos-styles.test.ts
+++ b/tests/pos-styles.test.ts
@@ -237,4 +237,26 @@ describe('POSStyleManager', () => {
     // Should not throw even though styleEl is now null
     expect(() => manager.update(DEFAULT_PROSE_HIGHLIGHT_SETTINGS)).not.toThrow();
   });
+
+  // --- F6: collision-safe class names ---
+
+  it('emits distinct color rules for word lists whose names collide', () => {
+    // "My List" and "my-list" both sanitize to "my-list". Without dedup,
+    // POSStyleManager would emit two rules for the same selector, and the
+    // second list's color would silently overwrite the first's.
+    const settings: ProseHighlightSettings = {
+      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      customWordLists: [
+        { name: 'My List', words: ['x'], color: '#aaaaaa', enabled: true, caseSensitive: false },
+        { name: 'my-list', words: ['y'], color: '#bbbbbb', enabled: true, caseSensitive: false },
+      ],
+    };
+
+    manager.init(settings);
+    const css = dom.styleEl.textContent;
+
+    // Both colors must be present, attached to distinct selectors.
+    expect(css).toContain('.yaae-list-my-list { color: #aaaaaa; }');
+    expect(css).toContain('.yaae-list-my-list-2 { color: #bbbbbb; }');
+  });
 });

--- a/tests/pos-styles.test.ts
+++ b/tests/pos-styles.test.ts
@@ -32,6 +32,23 @@ function setupDOM() {
   return { styleEl, headAppendChild, bodySetProperty };
 }
 
+/** Deep clone DEFAULT_PROSE_HIGHLIGHT_SETTINGS — the migration mutates the
+ * input to set posColorsMigrated, so passing the module-level constant
+ * directly poisons subsequent tests via shared state. */
+function freshDefaults(): ProseHighlightSettings {
+  return {
+    ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+    categories: {
+      adjective: { ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories.adjective },
+      noun: { ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories.noun },
+      adverb: { ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories.adverb },
+      verb: { ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories.verb },
+      conjunction: { ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories.conjunction },
+    },
+    customWordLists: [...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.customWordLists],
+  };
+}
+
 describe('POSStyleManager', () => {
   let manager: POSStyleManager;
   let dom: ReturnType<typeof setupDOM>;
@@ -48,13 +65,13 @@ describe('POSStyleManager', () => {
   // --- Style element lifecycle ---
 
   it('should create a <style> element on init', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     expect(document.createElement).toHaveBeenCalledWith('style');
     expect(dom.headAppendChild).toHaveBeenCalled();
   });
 
   it('should not emit .yaae-pos-* class selectors (static in styles.css)', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     const css = dom.styleEl.textContent;
 
     expect(css).not.toContain('.yaae-pos-adjective');
@@ -62,7 +79,7 @@ describe('POSStyleManager', () => {
   });
 
   it('should not emit POS variable rules into <style> (defaults live in styles.css)', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     const css = dom.styleEl.textContent;
 
     expect(css).not.toContain('--yaae-pos-adjective-color');
@@ -70,12 +87,12 @@ describe('POSStyleManager', () => {
   });
 
   it('should emit empty <style> textContent when no custom word lists exist', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     expect(dom.styleEl.textContent).toBe('');
   });
 
   it('should remove <style> element on destroy', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     manager.destroy();
     expect(dom.styleEl.remove).toHaveBeenCalled();
   });
@@ -83,15 +100,15 @@ describe('POSStyleManager', () => {
   // --- Migration (legacy POS color → body.style --yaae-pos-*-color-light) ---
 
   it('should not migrate when POS colors match defaults', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     expect(dom.bodySetProperty).not.toHaveBeenCalled();
   });
 
   it('should migrate non-default POS color to --yaae-pos-*-color-light on body', () => {
     const customized: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       categories: {
-        ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS.categories,
+        ...freshDefaults().categories,
         adjective: { enabled: true, color: '#ff0000' },
       },
     };
@@ -101,7 +118,7 @@ describe('POSStyleManager', () => {
 
   it('should migrate multiple non-default POS colors', () => {
     const customized: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       categories: {
         adjective: { enabled: true, color: '#ff0000' },
         noun: { enabled: true, color: '#00ff00' },
@@ -116,11 +133,62 @@ describe('POSStyleManager', () => {
     expect(dom.bodySetProperty).toHaveBeenCalledTimes(2);
   });
 
+  // --- F1: Migration latch (posColorsMigrated flag) ---
+
+  it('migration is one-shot: second init with the flag set does NOT re-stamp inline styles', () => {
+    const customized: ProseHighlightSettings = {
+      ...freshDefaults(),
+      categories: {
+        ...freshDefaults().categories,
+        adjective: { enabled: true, color: '#ff0000' },
+      },
+    };
+
+    // First init runs migration and flips the latch
+    manager.init(customized);
+    expect(dom.bodySetProperty).toHaveBeenCalledTimes(1);
+    expect(customized.posColorsMigrated).toBe(true);
+
+    // Second init must NOT re-stamp — would clobber Style Settings overrides
+    dom.bodySetProperty.mockClear();
+    manager.destroy();
+    manager.init(customized);
+    expect(dom.bodySetProperty).not.toHaveBeenCalled();
+  });
+
+  it('skips migration entirely when posColorsMigrated flag is already set', () => {
+    const previouslyMigrated: ProseHighlightSettings = {
+      ...freshDefaults(),
+      categories: {
+        ...freshDefaults().categories,
+        adjective: { enabled: true, color: '#deadbeef' },
+      },
+      posColorsMigrated: true,
+    };
+
+    manager.init(previouslyMigrated);
+    expect(dom.bodySetProperty).not.toHaveBeenCalled();
+  });
+
+  it('init() returns true when migration ran, false on subsequent runs', () => {
+    const customized: ProseHighlightSettings = {
+      ...freshDefaults(),
+      categories: {
+        ...freshDefaults().categories,
+        adjective: { enabled: true, color: '#ff0000' },
+      },
+    };
+
+    expect(manager.init(customized)).toBe(true);
+    manager.destroy();
+    expect(manager.init(customized)).toBe(false);
+  });
+
   // --- Custom word list rules ---
 
   it('should include custom word list CSS rules as direct class selectors', () => {
     const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         {
           name: 'Cloud Providers',
@@ -141,7 +209,7 @@ describe('POSStyleManager', () => {
 
   it('should handle multiple word lists', () => {
     const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: 'List A', words: ['foo'], color: '#aaa', enabled: true, caseSensitive: false },
         { name: 'List B', words: ['bar'], color: '#bbb', enabled: true, caseSensitive: false },
@@ -159,14 +227,14 @@ describe('POSStyleManager', () => {
 
   it('update() should replace old list rules with new ones', () => {
     manager.init({
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: 'Old', words: ['x'], color: '#111', enabled: true, caseSensitive: false },
       ],
     });
 
     manager.update({
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: 'New', words: ['y'], color: '#222', enabled: true, caseSensitive: false },
       ],
@@ -181,7 +249,7 @@ describe('POSStyleManager', () => {
   // --- Unhappy paths ---
 
   it('update() before init() should be a no-op', () => {
-    manager.update(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.update(freshDefaults());
     expect(dom.styleEl.textContent).toBe('');
   });
 
@@ -190,14 +258,14 @@ describe('POSStyleManager', () => {
   });
 
   it('destroy() called twice should not throw', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     manager.destroy();
     expect(() => manager.destroy()).not.toThrow();
   });
 
   it('should skip word lists with empty name', () => {
     const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: '', words: ['x'], color: '#abc', enabled: true, caseSensitive: false },
       ],
@@ -212,7 +280,7 @@ describe('POSStyleManager', () => {
 
   it('should skip word lists whose name sanitizes to empty', () => {
     const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: '!!!', words: ['x'], color: '#abc', enabled: true, caseSensitive: false },
       ],
@@ -226,8 +294,8 @@ describe('POSStyleManager', () => {
   });
 
   it('update() after destroy() should be a no-op', () => {
-    manager.init(DEFAULT_PROSE_HIGHLIGHT_SETTINGS);
+    manager.init(freshDefaults());
     manager.destroy();
-    expect(() => manager.update(DEFAULT_PROSE_HIGHLIGHT_SETTINGS)).not.toThrow();
+    expect(() => manager.update(freshDefaults())).not.toThrow();
   });
 });

--- a/tests/pos-styles.test.ts
+++ b/tests/pos-styles.test.ts
@@ -321,7 +321,7 @@ describe('POSStyleManager', () => {
     // POSStyleManager would emit two rules for the same selector, and the
     // second list's color would silently overwrite the first's.
     const settings: ProseHighlightSettings = {
-      ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+      ...freshDefaults(),
       customWordLists: [
         { name: 'My List', words: ['x'], color: '#aaaaaa', enabled: true, caseSensitive: false },
         { name: 'my-list', words: ['y'], color: '#bbbbbb', enabled: true, caseSensitive: false },

--- a/tests/print-styles.test.ts
+++ b/tests/print-styles.test.ts
@@ -288,6 +288,21 @@ describe('PageChromeManager', () => {
     // block must still be emitted with fallback light values
     expect(css).toContain('@media (prefers-color-scheme: dark)');
   });
+
+  // --- F5: Idempotent init (no orphan <style> on double-init) ---
+
+  it('PageChromeManager.init() called twice removes the first <style> before creating the second', () => {
+    manager.init(makeChrome());
+    const first = getLastStyleEl(dom.headAppendChild);
+    const callsBefore = dom.headAppendChild.mock.calls.length;
+
+    manager.init(makeChrome({ classification: 'confidential' }));
+
+    expect(first.remove).toHaveBeenCalled();
+    // One additional appendChild for the new element — and the old one
+    // is gone, so only one <style> with PAGE_CHROME_STYLE_ID is in <head>
+    expect(dom.headAppendChild.mock.calls.length).toBe(callsBefore + 1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -529,5 +544,18 @@ describe('DynamicPdfPrintStyleManager', () => {
     expect(css).toContain('font-family:');
     expect(css).toContain('.pdf-watermark-');
     expect(css).toContain('--print-line-height: 1.8');
+  });
+
+  // --- F5: Idempotent init (no orphan <style> on double-init) ---
+
+  it('init() called twice removes the first <style> before creating the second', () => {
+    manager.init(makeSettings());
+    const first = getLastStyleEl(dom.headAppendChild);
+    const callsBefore = dom.headAppendChild.mock.calls.length;
+
+    manager.init(makeSettings({ fontSize: 16 }));
+
+    expect(first.remove).toHaveBeenCalled();
+    expect(dom.headAppendChild.mock.calls.length).toBe(callsBefore + 1);
   });
 });

--- a/tests/print-styles.test.ts
+++ b/tests/print-styles.test.ts
@@ -255,6 +255,39 @@ describe('PageChromeManager', () => {
     const css = getLastStyleEl(dom.headAppendChild).textContent!;
     expect(css).not.toContain('prefers-color-scheme');
   });
+
+  // --- F3: auto theme always emits dark override even without explicit dark colors ---
+
+  it('auto theme: emits dark override for custom classification with no colorDark/backgroundDark', () => {
+    const customs: CustomClassification[] = [
+      // No colorDark or backgroundDark — must still get an auto override block
+      { id: 'orange', label: 'ORANGE', color: '#ff8800', background: '#fff0e0' },
+    ];
+    manager.init(makeChrome({
+      classification: 'orange',
+      customClassifications: customs,
+      theme: 'auto',
+    }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+
+    // Auto override must be present even without explicit dark variants
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+    expect(css).toContain('"ORANGE"');
+
+    // Dark block falls back to the light values (sanitizeColor passes them through)
+    const darkBlockStart = css.indexOf('@media (prefers-color-scheme: dark)');
+    expect(darkBlockStart).toBeGreaterThanOrEqual(0);
+    const darkBlock = css.substring(darkBlockStart);
+    expect(darkBlock).toContain('#ff8800');
+  });
+
+  it('auto theme: built-in classification (no dark variants) still emits dark override', () => {
+    manager.init(makeChrome({ classification: 'public', theme: 'auto' }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    // Built-in 'public' has no colorDark/backgroundDark — the override
+    // block must still be emitted with fallback light values
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/print-styles.test.ts
+++ b/tests/print-styles.test.ts
@@ -303,6 +303,81 @@ describe('PageChromeManager', () => {
     // is gone, so only one <style> with PAGE_CHROME_STYLE_ID is in <head>
     expect(dom.headAppendChild.mock.calls.length).toBe(callsBefore + 1);
   });
+
+  // --- Round-2: deeper structural assertions for auto-theme override ---
+
+  it('auto theme with no classification: no override block is emitted', () => {
+    // The override block is gated on `meta` being non-null — a doc with
+    // chrome but no classification (e.g. headers only) must not emit a
+    // dangling @media (prefers-color-scheme) referencing nothing.
+    manager.init(makeChrome({
+      theme: 'auto',
+      headerLeft: 'Acme',
+      pageNumbers: true,
+    }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    expect(css).toContain('@top-left');
+    expect(css).not.toContain('prefers-color-scheme');
+  });
+
+  it('auto theme override block contains @page with @top-center inside', () => {
+    // Structural sanity — the nested override must wrap a complete
+    // @page { ... } so Chromium accepts it. Asserting the substring
+    // "@page {" appears AFTER "@media (prefers-color-scheme: dark)"
+    // protects against a regression that lifts the override block out
+    // of the @media print scope or drops the @page wrapper.
+    manager.init(makeChrome({ classification: 'confidential', theme: 'auto' }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    const darkIdx = css.indexOf('@media (prefers-color-scheme: dark)');
+    expect(darkIdx).toBeGreaterThan(0);
+    const overrideTail = css.slice(darkIdx);
+    expect(overrideTail).toMatch(/@page\s*\{/);
+    expect(overrideTail).toContain('@top-center');
+  });
+
+  it('auto theme with bannerPosition both: dark override emits both @top-center and @bottom-center', () => {
+    manager.init(makeChrome({
+      classification: 'confidential',
+      theme: 'auto',
+      bannerPosition: 'both',
+    }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    const darkIdx = css.indexOf('@media (prefers-color-scheme: dark)');
+    const overrideTail = css.slice(darkIdx);
+    expect(overrideTail).toContain('@top-center');
+    expect(overrideTail).toContain('@bottom-center');
+  });
+
+  it('dark theme bakes built-in colorDark statically (not the light values)', () => {
+    // Confidential built-in: light=#c41e1e, dark=#ff7777. Theme=dark must
+    // emit #ff7777 in the *base* @page block, not the light value.
+    manager.init(makeChrome({ classification: 'confidential', theme: 'dark' }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    expect(css).toContain('#ff7777');
+    expect(css).toContain('#3a1818');
+    // Light values must not appear in the dark-theme baked output for the
+    // same banner — would mean we emitted the wrong base.
+    expect(css).not.toContain('#c41e1e');
+    expect(css).not.toContain('#fff5f5');
+  });
+
+  it('dark theme falls back to light color when colorDark is absent', () => {
+    // Custom classification with no dark variants — `theme: dark` should
+    // pass the light values through (sanitized).
+    const customs: CustomClassification[] = [
+      { id: 'orange', label: 'ORANGE', color: '#ff8800', background: '#fff0e0' },
+    ];
+    manager.init(makeChrome({
+      classification: 'orange',
+      customClassifications: customs,
+      theme: 'dark',
+    }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    expect(css).toContain('#ff8800');
+    expect(css).toContain('#fff0e0');
+    // No prefers-color-scheme block in pure dark theme
+    expect(css).not.toContain('prefers-color-scheme');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/print-styles.test.ts
+++ b/tests/print-styles.test.ts
@@ -47,6 +47,7 @@ const DEFAULT_CHROME: PageChromeState = {
   signatureBlock: false,
   bannerPosition: 'both',
   showClassificationBanner: true,
+  theme: 'light',
 };
 
 function makeChrome(overrides: Partial<PageChromeState> = {}): PageChromeState {
@@ -211,6 +212,48 @@ describe('PageChromeManager', () => {
     manager.init(makeChrome({ classification: 'nonexistent-level' }));
     const css = getLastStyleEl(dom.headAppendChild).textContent!;
     expect(css).toBe('');
+  });
+
+  // --- F2: nested @media (prefers-color-scheme: dark), not the combined form ---
+
+  it('auto theme: nests @media (prefers-color-scheme: dark) inside @media print', () => {
+    const customs: CustomClassification[] = [
+      // Trigger the dark override path with explicit dark colors so the
+      // current `colorDark || backgroundDark` guard emits the block
+      { id: 'topsec', label: 'TOP SECRET', color: '#660000', background: '#fff0f0', colorDark: '#ff8888', backgroundDark: '#330000' },
+    ];
+    manager.init(makeChrome({
+      classification: 'topsec',
+      customClassifications: customs,
+      theme: 'auto',
+    }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+
+    // The combined form is silently ignored by Chromium's print engine
+    expect(css).not.toContain('@media print and (prefers-color-scheme: dark)');
+
+    // Working form: outer @media print { ... @media (prefers-color-scheme: dark) { ... } }
+    expect(css).toContain('@media print {');
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+
+    // Verify nesting — dark block must appear *inside* the @media print
+    // block, not as a top-level sibling
+    const printIdx = css.indexOf('@media print {');
+    const darkIdx = css.indexOf('@media (prefers-color-scheme: dark)');
+    expect(printIdx).toBeGreaterThanOrEqual(0);
+    expect(darkIdx).toBeGreaterThan(printIdx);
+  });
+
+  it('light theme: emits no prefers-color-scheme override', () => {
+    manager.init(makeChrome({ classification: 'confidential', theme: 'light' }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    expect(css).not.toContain('prefers-color-scheme');
+  });
+
+  it('dark theme: bakes dark colors statically, no @media override', () => {
+    manager.init(makeChrome({ classification: 'confidential', theme: 'dark' }));
+    const css = getLastStyleEl(dom.headAppendChild).textContent!;
+    expect(css).not.toContain('prefers-color-scheme');
   });
 });
 

--- a/tests/reading-view.test.ts
+++ b/tests/reading-view.test.ts
@@ -35,8 +35,12 @@ function makeList(overrides: Partial<CustomWordList> = {}): CustomWordList {
 // Minimal stub for the post-processor's HTMLElement / TreeWalker contract.
 // We only care that text nodes are processed; tests for F5 spy on the
 // matcher to confirm compile-rate, and tests for F7 hit buildSpans directly.
-function makePlugin(s: ProseHighlightSettings) {
-  return { settings: { proseHighlight: s } } as never;
+type ReadingViewPluginArg = Parameters<typeof createReadingViewPostProcessor>[0];
+type ReadingViewProcessor = ReturnType<typeof createReadingViewPostProcessor>;
+type ReadingViewProcessorContext = Parameters<ReadingViewProcessor>[1];
+
+function makePlugin(s: ProseHighlightSettings): ReadingViewPluginArg {
+  return { settings: { proseHighlight: s } } as ReadingViewPluginArg;
 }
 
 // Restore globalThis stubs after each test so the file is self-contained
@@ -100,9 +104,10 @@ describe('reading-view post-processor (F5: regex compile rate)', () => {
     // Three calls = three render cycles for three blocks. The settings
     // array reference is the same across all three, so compile must run
     // exactly once total.
-    processor(makeBlockEl('foo bar'), {} as never);
-    processor(makeBlockEl('foo baz'), {} as never);
-    processor(makeBlockEl('foo qux'), {} as never);
+    const ctx = {} as ReadingViewProcessorContext;
+    processor(makeBlockEl('foo bar'), ctx);
+    processor(makeBlockEl('foo baz'), ctx);
+    processor(makeBlockEl('foo qux'), ctx);
 
     expect(compileSpy).toHaveBeenCalledTimes(1);
     compileSpy.mockRestore();
@@ -116,17 +121,18 @@ describe('reading-view post-processor (F5: regex compile rate)', () => {
 
     const lists1: CustomWordList[] = [makeList({ words: ['foo'] })];
     const settings1 = settings({ customWordLists: lists1 });
-    const plugin = { settings: { proseHighlight: settings1 } } as never;
+    const plugin = { settings: { proseHighlight: settings1 } } as ReadingViewPluginArg;
     const processor = createReadingViewPostProcessor(plugin);
 
-    processor(makeBlockEl('foo bar'), {} as never);
+    const ctx = {} as ReadingViewProcessorContext;
+    processor(makeBlockEl('foo bar'), ctx);
     expect(compileSpy).toHaveBeenCalledTimes(1);
 
     // Swap to a new lists array (simulates settings save).
     const lists2: CustomWordList[] = [makeList({ words: ['baz'] })];
     plugin.settings.proseHighlight = settings({ customWordLists: lists2 });
 
-    processor(makeBlockEl('foo bar'), {} as never);
+    processor(makeBlockEl('foo bar'), ctx);
     expect(compileSpy).toHaveBeenCalledTimes(2);
 
     compileSpy.mockRestore();

--- a/tests/reading-view.test.ts
+++ b/tests/reading-view.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildSpans,
+  createReadingViewPostProcessor,
+} from '../src/prose-highlight/reading-view';
+import { WordListMatcher } from '../src/prose-highlight/word-lists';
+import type { POSTag } from '../src/prose-highlight/tagger';
+import type { WordListMatch } from '../src/prose-highlight/word-lists';
+import {
+  DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+  type ProseHighlightSettings,
+  type CustomWordList,
+} from '../src/types';
+
+function settings(partial: Partial<ProseHighlightSettings> = {}): ProseHighlightSettings {
+  return {
+    ...DEFAULT_PROSE_HIGHLIGHT_SETTINGS,
+    enabled: true,
+    readingViewEnabled: true,
+    ...partial,
+  };
+}
+
+function makeList(overrides: Partial<CustomWordList> = {}): CustomWordList {
+  return {
+    name: 'list',
+    words: ['foo'],
+    color: '#fff',
+    enabled: true,
+    caseSensitive: false,
+    ...overrides,
+  };
+}
+
+// Minimal stub for the post-processor's HTMLElement / TreeWalker contract.
+// We only care that text nodes are processed; tests for F5 spy on the
+// matcher to confirm compile-rate, and tests for F7 hit buildSpans directly.
+function makePlugin(s: ProseHighlightSettings) {
+  return { settings: { proseHighlight: s } } as never;
+}
+
+function makeBlockEl(text: string): HTMLElement {
+  // jsdom is not enabled — fabricate the minimum shape the post-processor
+  // touches: TreeWalker + Text nodes. We construct a tiny DOM-compatible
+  // graph manually so the post-processor doesn't crash.
+  const textNode = {
+    textContent: text,
+    parentElement: null,
+    parentNode: { replaceChild: vi.fn() },
+  };
+  const walker = {
+    _nodes: [textNode],
+    _i: -1,
+    currentNode: null as unknown,
+    nextNode() {
+      this._i++;
+      if (this._i >= this._nodes.length) return null;
+      this.currentNode = this._nodes[this._i];
+      return this.currentNode;
+    },
+  };
+  // Stash on globalThis.document for the duration of the call.
+  (globalThis as Record<string, unknown>).document = {
+    createTreeWalker: () => walker,
+    createDocumentFragment: () => ({ appendChild: vi.fn() }),
+    createElement: () => ({ className: '', textContent: '' }),
+    createTextNode: (t: string) => ({ textContent: t }),
+  };
+  // NodeFilter is referenced by the post-processor; stub the constants it
+  // uses so the call site doesn't throw in node-environment tests.
+  (globalThis as Record<string, unknown>).NodeFilter = {
+    SHOW_TEXT: 4,
+    FILTER_ACCEPT: 1,
+    FILTER_REJECT: 2,
+    FILTER_SKIP: 3,
+  };
+  // The post-processor only uses `el` to scope the walker, never reads it.
+  return {} as HTMLElement;
+}
+
+describe('reading-view post-processor (F5: regex compile rate)', () => {
+  it('compiles word lists once per render, not per text node', () => {
+    const compileSpy = vi.spyOn(
+      WordListMatcher.prototype,
+      'compile',
+    );
+
+    const lists: CustomWordList[] = [makeList({ words: ['foo'] })];
+    const plugin = makePlugin(settings({ customWordLists: lists }));
+    const processor = createReadingViewPostProcessor(plugin);
+
+    // Three calls = three render cycles for three blocks. The settings
+    // array reference is the same across all three, so compile must run
+    // exactly once total.
+    processor(makeBlockEl('foo bar'), {} as never);
+    processor(makeBlockEl('foo baz'), {} as never);
+    processor(makeBlockEl('foo qux'), {} as never);
+
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+    compileSpy.mockRestore();
+  });
+
+  it('recompiles when the settings array reference changes', () => {
+    const compileSpy = vi.spyOn(
+      WordListMatcher.prototype,
+      'compile',
+    );
+
+    const lists1: CustomWordList[] = [makeList({ words: ['foo'] })];
+    const settings1 = settings({ customWordLists: lists1 });
+    const plugin = { settings: { proseHighlight: settings1 } } as never;
+    const processor = createReadingViewPostProcessor(plugin);
+
+    processor(makeBlockEl('foo bar'), {} as never);
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+
+    // Swap to a new lists array (simulates settings save).
+    const lists2: CustomWordList[] = [makeList({ words: ['baz'] })];
+    plugin.settings.proseHighlight = settings({ customWordLists: lists2 });
+
+    processor(makeBlockEl('foo bar'), {} as never);
+    expect(compileSpy).toHaveBeenCalledTimes(2);
+
+    compileSpy.mockRestore();
+  });
+});
+
+describe('buildSpans (F7: per-character overlap)', () => {
+  function posSettings() {
+    return {
+      categories: {
+        adjective: { enabled: true },
+        noun: { enabled: true },
+        adverb: { enabled: true },
+        verb: { enabled: true },
+        conjunction: { enabled: true },
+      },
+    };
+  }
+
+  it('suppresses a POS tag when a list match covers any of its positions', () => {
+    // List match "oo" at [6, 8) lives inside POS tag "good" at [5, 9).
+    // Old code only checked tag.start (5), which was NOT covered, so both
+    // spans were emitted and the rendered fragment was corrupt.
+    const posTags: POSTag[] = [
+      { text: 'good', pos: 'adjective', start: 5, end: 9 },
+    ];
+    const listMatches: WordListMatch[] = [
+      {
+        text: 'oo',
+        listName: 'mid-overlap',
+        cssClass: 'yaae-list-mid-overlap',
+        start: 6,
+        end: 8,
+      },
+    ];
+
+    const spans = buildSpans(posTags, listMatches, posSettings());
+    // Only the list match survives.
+    expect(spans).toHaveLength(1);
+    expect(spans[0].cssClass).toBe('yaae-list-mid-overlap');
+    expect(spans[0].start).toBe(6);
+    expect(spans[0].end).toBe(8);
+  });
+
+  it('keeps non-overlapping POS tags', () => {
+    const posTags: POSTag[] = [
+      { text: 'good', pos: 'adjective', start: 0, end: 4 },
+      { text: 'cat', pos: 'noun', start: 5, end: 8 },
+    ];
+    const listMatches: WordListMatch[] = [
+      {
+        text: 'cat',
+        listName: 'animals',
+        cssClass: 'yaae-list-animals',
+        start: 5,
+        end: 8,
+      },
+    ];
+
+    const spans = buildSpans(posTags, listMatches, posSettings());
+    // POS "good" survives; POS "cat" is suppressed; list "cat" wins.
+    expect(spans).toHaveLength(2);
+    const classes = spans.map((s) => s.cssClass);
+    expect(classes).toContain('yaae-pos-adjective');
+    expect(classes).toContain('yaae-list-animals');
+    expect(classes).not.toContain('yaae-pos-noun');
+  });
+
+  it('drops POS tags whose start is outside but body overlaps a list match', () => {
+    // Tag spans [10, 20). List spans [15, 17), entirely inside.
+    const posTags: POSTag[] = [
+      { text: 'wonderful', pos: 'adjective', start: 10, end: 20 },
+    ];
+    const listMatches: WordListMatch[] = [
+      {
+        text: 'der',
+        listName: 'mid',
+        cssClass: 'yaae-list-mid',
+        start: 15,
+        end: 18,
+      },
+    ];
+
+    const spans = buildSpans(posTags, listMatches, posSettings());
+    expect(spans).toHaveLength(1);
+    expect(spans[0].cssClass).toBe('yaae-list-mid');
+  });
+});

--- a/tests/reading-view.test.ts
+++ b/tests/reading-view.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   buildSpans,
   createReadingViewPostProcessor,
@@ -38,6 +38,14 @@ function makeList(overrides: Partial<CustomWordList> = {}): CustomWordList {
 function makePlugin(s: ProseHighlightSettings) {
   return { settings: { proseHighlight: s } } as never;
 }
+
+// Restore globalThis stubs after each test so the file is self-contained
+// and any future test added to this suite can't accidentally inherit
+// half-mocked DOM globals from a prior test.
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).document;
+  delete (globalThis as Record<string, unknown>).NodeFilter;
+});
 
 function makeBlockEl(text: string): HTMLElement {
   // jsdom is not enabled — fabricate the minimum shape the post-processor

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1077,6 +1077,31 @@ describe('getClassificationMeta', () => {
     expect(meta!.label).toBe('UNCLASSIFIED');
     expect(meta!.color).toBe('#333333');
   });
+
+  // F3: whitespace mismatch — raw frontmatter `"  internal  "` resolves
+  // to `internal` in PageChromeManager (Zod-trimmed) but used to fail
+  // strict equality here, leaving the banner blank while the PDF rendered
+  // with classification. Both call sites must converge on the trimmed ID.
+  it('trims whitespace before lookup so "  internal  " resolves to internal meta', () => {
+    const meta = getClassificationMeta('  internal  ', []);
+    expect(meta).not.toBeNull();
+    expect(meta!.label).toBe(CLASSIFICATION_TAXONOMY.internal.label);
+    expect(meta!.color).toBe(CLASSIFICATION_TAXONOMY.internal.color);
+  });
+
+  it('trims whitespace before custom-classification lookup', () => {
+    const customs: CustomClassification[] = [
+      { id: 'sensitive', label: 'SENSITIVE', color: '#b8860b', background: '#fff8e7' },
+    ];
+    const meta = getClassificationMeta('\tsensitive\n', customs);
+    expect(meta).not.toBeNull();
+    expect(meta!.label).toBe('SENSITIVE');
+  });
+
+  it('returns null for whitespace-only level string', () => {
+    expect(getClassificationMeta('   ')).toBeNull();
+    expect(getClassificationMeta('\t\n')).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1107,5 +1132,30 @@ describe('getAllClassificationIds', () => {
     const ids = getAllClassificationIds(customs);
     const publicCount = ids.filter((id) => id === 'public').length;
     expect(publicCount).toBe(1);
+  });
+
+  // F6: empty/whitespace IDs would surface as a blank option in the
+  // Default Classification dropdown; selecting it sets defaultClassification
+  // to "" and silently disables the banner.
+  it('excludes empty custom IDs', () => {
+    const customs: CustomClassification[] = [
+      { id: '', label: 'BLANK', color: '#333', background: '#eee' },
+      { id: 'foo', label: 'FOO', color: '#333', background: '#eee' },
+    ];
+    const ids = getAllClassificationIds(customs);
+    expect(ids).not.toContain('');
+    expect(ids).toContain('foo');
+  });
+
+  it('excludes whitespace-only custom IDs', () => {
+    const customs: CustomClassification[] = [
+      { id: '   ', label: 'BLANK', color: '#333', background: '#eee' },
+      { id: '\t', label: 'TAB', color: '#333', background: '#eee' },
+      { id: 'foo', label: 'FOO', color: '#333', background: '#eee' },
+    ];
+    const ids = getAllClassificationIds(customs);
+    expect(ids).not.toContain('   ');
+    expect(ids).not.toContain('\t');
+    expect(ids).toContain('foo');
   });
 });

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1131,6 +1131,78 @@ describe('getClassificationMeta', () => {
     expect(getClassificationMeta('   ')).toBeNull();
     expect(getClassificationMeta('\t\n')).toBeNull();
   });
+
+  // Round-2: trim BOTH the lookup level AND the stored custom ID. A user can
+  // (via direct data.json edit, or paste-with-spaces in a future settings UI)
+  // end up with `id: ' sensitive '` in their custom list. Without trimming
+  // the stored id, a frontmatter `classification: sensitive` would miss the
+  // match and silently leave the document unclassified.
+  it('trims whitespace from stored custom ID before matching', () => {
+    const customs: CustomClassification[] = [
+      { id: '  sensitive  ', label: 'SENSITIVE', color: '#b8860b', background: '#fff8e7' },
+    ];
+    const meta = getClassificationMeta('sensitive', customs);
+    expect(meta).not.toBeNull();
+    expect(meta!.label).toBe('SENSITIVE');
+    // Returned level must be the canonical (trimmed) form so downstream
+    // class derivation (e.g. `pdf-${level}`) is stable.
+    expect(meta!.level).toBe('sensitive');
+  });
+
+  it('matches when both lookup level and stored ID have surrounding whitespace', () => {
+    const customs: CustomClassification[] = [
+      { id: ' top-secret ', label: 'TOP SECRET', color: '#800000', background: '#fee' },
+    ];
+    const meta = getClassificationMeta('\ttop-secret\n', customs);
+    expect(meta).not.toBeNull();
+    expect(meta!.level).toBe('top-secret');
+  });
+
+  it('ignores custom entries whose ID is whitespace-only', () => {
+    // A custom row in mid-edit with id=' ' must not shadow built-ins or
+    // resolve as a wildcard — getClassificationMeta returns null for the
+    // whitespace input above, so this confirms the negative case for a
+    // non-empty lookup against a malformed custom row.
+    const customs: CustomClassification[] = [
+      { id: '   ', label: 'BLANK', color: '#000', background: '#fff' },
+      { id: 'real', label: 'REAL', color: '#111', background: '#eee' },
+    ];
+    expect(getClassificationMeta('real', customs)?.label).toBe('REAL');
+    // The blank-ID entry must not collide with non-empty lookups
+    expect(getClassificationMeta('blank', customs)).toBeNull();
+  });
+
+  it('preserves dark-theme overrides on custom classifications', () => {
+    // Round-2: ClassificationMeta gained colorDark/backgroundDark; the
+    // lookup must propagate them so PageChromeManager + banner CSS can
+    // select dark variants.
+    const customs: CustomClassification[] = [
+      {
+        id: 'topsec',
+        label: 'TOP SECRET',
+        color: '#660000',
+        background: '#fff0f0',
+        colorDark: '#ff8888',
+        backgroundDark: '#330000',
+      },
+    ];
+    const meta = getClassificationMeta('topsec', customs);
+    expect(meta).not.toBeNull();
+    expect(meta!.colorDark).toBe('#ff8888');
+    expect(meta!.backgroundDark).toBe('#330000');
+  });
+
+  it('leaves dark fields undefined when custom classification omits them', () => {
+    // Inheritance contract — undefined here signals "fall back to light
+    // values" downstream (PageChromeManager uses `colorDark ?? color`).
+    const customs: CustomClassification[] = [
+      { id: 'plain', label: 'PLAIN', color: '#000', background: '#fff' },
+    ];
+    const meta = getClassificationMeta('plain', customs);
+    expect(meta).not.toBeNull();
+    expect(meta!.colorDark).toBeUndefined();
+    expect(meta!.backgroundDark).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -13,6 +13,9 @@ import type { CustomClassification } from '../src/schemas';
 const wrap = (yaml: string, body = '') =>
   `---\n${yaml}\n---\n${body}`;
 
+/** Matches strings safe for use as CSS class names (no whitespace, no selector chars). */
+const SAFE_CSS_FRAGMENT_RE = /^[a-zA-Z0-9_-]+$/;
+
 // ---------------------------------------------------------------------------
 // extractFrontmatter
 // ---------------------------------------------------------------------------
@@ -587,6 +590,32 @@ describe('deriveCssClasses', () => {
     expect(classes).toContain('pdf-copy-safe');
     expect(classes).toContain('pdf-compact-tables');
     expect(classes).toContain('pdf-font-sans');
+  });
+
+  // F4: data.json can be tampered directly to bypass Zod, so deriveCssClasses
+  // must sanitize before interpolating into class strings. Otherwise
+  // classList.add() will throw on whitespace-bearing class names.
+  it('skips classification class when value contains injection characters', () => {
+    const tampered = {
+      classification: 'internal extra-class',
+      status: 'draft',
+      export: { pdf: {} },
+    } as any;
+    const classes = deriveCssClasses(tampered);
+    // No `pdf-internal extra-class` token (would explode on classList.add)
+    expect(classes.every((c) => !c.includes(' '))).toBe(true);
+    expect(classes.find((c) => c.startsWith('pdf-internal'))).toBeUndefined();
+  });
+
+  it('skips status class when value contains injection characters', () => {
+    const tampered = {
+      classification: 'internal',
+      status: 'draft } * { display: none',
+      export: { pdf: {} },
+    } as any;
+    const classes = deriveCssClasses(tampered);
+    expect(classes.every((c) => SAFE_CSS_FRAGMENT_RE.test(c))).toBe(true);
+    expect(classes.find((c) => c.startsWith('pdf-draft '))).toBeUndefined();
   });
 
   it('includes watermark class when set', () => {

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -60,3 +60,30 @@ describe('isValidClassificationId (F3 save guard)', () => {
     expect(isValidClassificationId(sanitized)).toBe(true);
   });
 });
+
+describe('draft-entry persistence gate (F2)', () => {
+  // The Add classification flow holds an in-memory draft until the user types
+  // a valid ID. Persisting hinges on isValidClassificationId — these tests
+  // document the per-keystroke save decision.
+  type Stage = 'create' | 'typing' | 'invalid' | 'valid';
+  const shouldPersist = (id: string, stage: Stage) =>
+    stage !== 'create' && isValidClassificationId(id);
+
+  it('does not persist on initial Add click', () => {
+    expect(shouldPersist('', 'create')).toBe(false);
+  });
+
+  it('does not persist while ID is empty', () => {
+    expect(shouldPersist('', 'typing')).toBe(false);
+  });
+
+  it('does not persist while ID is whitespace-only (post-sanitize: hyphen)', () => {
+    const sanitized = sanitizeClassificationId('   ');
+    expect(shouldPersist(sanitized, 'invalid')).toBe(false);
+  });
+
+  it('persists once ID has at least one alphanumeric char', () => {
+    const sanitized = sanitizeClassificationId('non sensitive');
+    expect(shouldPersist(sanitized, 'valid')).toBe(true);
+  });
+});

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+  FONT_CUSTOM_SENTINEL,
+  isFontPreset,
   isValidClassificationId,
   sanitizeClassificationId,
 } from '../src/document/settings-tab-helpers';
@@ -85,5 +87,57 @@ describe('draft-entry persistence gate (F2)', () => {
   it('persists once ID has at least one alphanumeric char', () => {
     const sanitized = sanitizeClassificationId('non sensitive');
     expect(shouldPersist(sanitized, 'valid')).toBe(true);
+  });
+});
+
+describe('isFontPreset (F4 dropdown detection)', () => {
+  it('recognizes the four named presets', () => {
+    expect(isFontPreset('sans')).toBe(true);
+    expect(isFontPreset('serif')).toBe(true);
+    expect(isFontPreset('mono')).toBe(true);
+    expect(isFontPreset('system')).toBe(true);
+  });
+
+  it('rejects arbitrary font strings', () => {
+    expect(isFontPreset('Inter')).toBe(false);
+    expect(isFontPreset('"Helvetica Neue", sans-serif')).toBe(false);
+    expect(isFontPreset('')).toBe(false);
+  });
+
+  it('rejects the custom sentinel itself (UI-only marker)', () => {
+    // The sentinel is a UI-only marker — it must never round-trip into
+    // settings as if it were a real preset.
+    expect(isFontPreset(FONT_CUSTOM_SENTINEL)).toBe(false);
+  });
+});
+
+describe('font-family persistence behavior (F4)', () => {
+  // These tests document the contract: arbitrary `fontFamily` values must
+  // survive a no-op dropdown interaction. The dropdown UI uses isFontPreset
+  // to decide whether to render the value as a preset selection or as the
+  // custom sentinel.
+  it('arbitrary font value displays via the Custom branch', () => {
+    const stored = 'Inter';
+    const displayValue = isFontPreset(stored) ? stored : FONT_CUSTOM_SENTINEL;
+    expect(displayValue).toBe(FONT_CUSTOM_SENTINEL);
+  });
+
+  it('preset value displays as itself', () => {
+    const stored = 'serif';
+    const displayValue = isFontPreset(stored) ? stored : FONT_CUSTOM_SENTINEL;
+    expect(displayValue).toBe('serif');
+  });
+
+  it('arbitrary fontFamily survives a no-op dropdown interaction', () => {
+    // Simulating: user has 'Inter' stored, opens the dropdown (which shows
+    // 'Custom...' selected), clicks 'Custom...' again. The new dropdown
+    // value is the sentinel, which the onChange handler treats as "reveal
+    // input, do not overwrite".
+    let stored = 'Inter';
+    const newDropdownValue = FONT_CUSTOM_SENTINEL;
+    if (newDropdownValue !== FONT_CUSTOM_SENTINEL) {
+      stored = newDropdownValue;
+    }
+    expect(stored).toBe('Inter');
   });
 });

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -85,7 +85,7 @@ describe('draft-entry persistence gate (F2)', () => {
     expect(shouldPersist('', 'typing')).toBe(false);
   });
 
-  it('does not persist while ID is whitespace-only (post-sanitize: hyphen)', () => {
+  it('does not persist while ID is whitespace-only (post-sanitize: empty string)', () => {
     const sanitized = sanitizeClassificationId('   ');
     expect(shouldPersist(sanitized, 'invalid')).toBe(false);
   });

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -20,16 +20,21 @@ describe('sanitizeClassificationId', () => {
     expect(sanitizeClassificationId('non!@#sensitive')).toBe('nonsensitive');
   });
 
-  it('produces a hyphen for whitespace-only input (documenting the F3 bug surface)', () => {
-    // The sanitizer collapses any run of whitespace into a single hyphen
-    // via `\s+`. The result is non-empty — passing the prior truthy save
-    // guard `if (entry.id)` and persisting `id: '-'`. isValidClassificationId
-    // is what protects us going forward.
-    expect(sanitizeClassificationId('   ')).toBe('-');
+  it('produces empty string for whitespace-only input', () => {
+    // Sanitizer trims edge whitespace and strips edge hyphens, so
+    // whitespace-only input collapses to ''. isValidClassificationId then
+    // rejects it as a save guard.
+    expect(sanitizeClassificationId('   ')).toBe('');
   });
 
   it('produces empty string for input with no allowed chars', () => {
     expect(sanitizeClassificationId('!@#$%')).toBe('');
+  });
+
+  it('trims edge whitespace and strips edge hyphens', () => {
+    expect(sanitizeClassificationId(' non sensitive ')).toBe('non-sensitive');
+    expect(sanitizeClassificationId('-foo-')).toBe('foo');
+    expect(sanitizeClassificationId('--foo--bar--')).toBe('foo-bar');
   });
 });
 
@@ -52,7 +57,7 @@ describe('isValidClassificationId (F3 save guard)', () => {
 
   it('end-to-end: whitespace-only input is sanitized then rejected', () => {
     const sanitized = sanitizeClassificationId('   ');
-    expect(sanitized).toBe('-');
+    expect(sanitized).toBe('');
     expect(isValidClassificationId(sanitized)).toBe(false);
   });
 

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   FONT_CUSTOM_SENTINEL,
+  FONT_PRESETS,
   isFontPreset,
   isValidClassificationId,
   sanitizeClassificationId,
@@ -144,5 +145,43 @@ describe('font-family persistence behavior (F4)', () => {
       stored = newDropdownValue;
     }
     expect(stored).toBe('Inter');
+  });
+});
+
+// --- Round-2: FONT_PRESETS / isFontPreset coupling ---
+// FONT_PRESETS is the source of truth for the dropdown; isFontPreset is the
+// runtime check the settings UI uses to decide between the preset branch
+// and the custom-input branch. They must agree on every entry, both
+// directions, or the dropdown will overwrite arbitrary font strings.
+
+describe('FONT_PRESETS / isFontPreset agreement', () => {
+  it('isFontPreset accepts every member of FONT_PRESETS', () => {
+    for (const preset of FONT_PRESETS) {
+      expect(isFontPreset(preset)).toBe(true);
+    }
+  });
+
+  it('FONT_PRESETS contains exactly the four named presets in stable order', () => {
+    // Order matters — the dropdown is rendered from this list. Lock it in
+    // so a refactor that reorders or trims silently fails the test.
+    expect([...FONT_PRESETS]).toEqual(['sans', 'serif', 'mono', 'system']);
+  });
+
+  it('FONT_CUSTOM_SENTINEL is not a member of FONT_PRESETS', () => {
+    // The sentinel must never collide with a real preset, otherwise the
+    // dropdown's "Custom..." option would be indistinguishable from a
+    // preset selection on first render.
+    expect((FONT_PRESETS as readonly string[]).includes(FONT_CUSTOM_SENTINEL))
+      .toBe(false);
+  });
+
+  it('isFontPreset rejects values that look like preset names but differ in case', () => {
+    // Settings round-trip is case-sensitive; "Sans" stored from a tampered
+    // data.json must take the Custom branch so it surfaces in the input
+    // (and the user can fix or accept it).
+    expect(isFontPreset('Sans')).toBe(false);
+    expect(isFontPreset('SERIF')).toBe(false);
+    expect(isFontPreset(' sans')).toBe(false);
+    expect(isFontPreset('sans ')).toBe(false);
   });
 });

--- a/tests/settings-tab-helpers.test.ts
+++ b/tests/settings-tab-helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidClassificationId,
+  sanitizeClassificationId,
+} from '../src/document/settings-tab-helpers';
+
+describe('sanitizeClassificationId', () => {
+  it('lowercases input', () => {
+    expect(sanitizeClassificationId('NON-Sensitive')).toBe('non-sensitive');
+  });
+
+  it('replaces whitespace runs with hyphens', () => {
+    expect(sanitizeClassificationId('non sensitive')).toBe('non-sensitive');
+    expect(sanitizeClassificationId('non   sensitive')).toBe('non-sensitive');
+  });
+
+  it('strips disallowed characters', () => {
+    expect(sanitizeClassificationId('non!@#sensitive')).toBe('nonsensitive');
+  });
+
+  it('produces a hyphen for whitespace-only input (documenting the F3 bug surface)', () => {
+    // The sanitizer collapses any run of whitespace into a single hyphen
+    // via `\s+`. The result is non-empty — passing the prior truthy save
+    // guard `if (entry.id)` and persisting `id: '-'`. isValidClassificationId
+    // is what protects us going forward.
+    expect(sanitizeClassificationId('   ')).toBe('-');
+  });
+
+  it('produces empty string for input with no allowed chars', () => {
+    expect(sanitizeClassificationId('!@#$%')).toBe('');
+  });
+});
+
+describe('isValidClassificationId (F3 save guard)', () => {
+  it('rejects an empty string', () => {
+    expect(isValidClassificationId('')).toBe(false);
+  });
+
+  it('rejects a string of hyphens (whitespace-only sanitized)', () => {
+    expect(isValidClassificationId('-')).toBe(false);
+    expect(isValidClassificationId('---')).toBe(false);
+  });
+
+  it('accepts an ID with at least one alphanumeric char', () => {
+    expect(isValidClassificationId('a')).toBe(true);
+    expect(isValidClassificationId('non-sensitive')).toBe(true);
+    expect(isValidClassificationId('-x-')).toBe(true);
+    expect(isValidClassificationId('1')).toBe(true);
+  });
+
+  it('end-to-end: whitespace-only input is sanitized then rejected', () => {
+    const sanitized = sanitizeClassificationId('   ');
+    expect(sanitized).toBe('-');
+    expect(isValidClassificationId(sanitized)).toBe(false);
+  });
+
+  it('end-to-end: legitimate input is sanitized then accepted', () => {
+    const sanitized = sanitizeClassificationId('Non Sensitive');
+    expect(sanitized).toBe('non-sensitive');
+    expect(isValidClassificationId(sanitized)).toBe(true);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,7 +6,10 @@ import { vi } from 'vitest';
 // Mock document for DOM operations
 const mockDocument = {
   createElement: vi.fn((tag: string) => ({
-    style: {},
+    style: {
+      cssText: '',
+      setProperty: vi.fn(),
+    },
     classList: { add: vi.fn(), remove: vi.fn() },
     setAttribute: vi.fn(),
     appendChild: vi.fn(),
@@ -17,6 +20,9 @@ const mockDocument = {
   body: {
     appendChild: vi.fn(),
     removeChild: vi.fn(),
+    style: {
+      setProperty: vi.fn(),
+    },
   },
 };
 

--- a/tests/toc-generator.test.ts
+++ b/tests/toc-generator.test.ts
@@ -32,12 +32,13 @@ describe('generateToc', () => {
     expect(entryCount).toBe(2); // H2 + H3, not H4
   });
 
-  it('indents nested headings', () => {
+  it('indents nested headings relative to the shallowest level', () => {
+    // Shallowest is H2; H3 nests by one level (2 spaces), H4 by two (4 spaces).
     const content = fm('\n## Parent\n\n### Child\n\n#### Grandchild\n');
     const { content: result } = generateToc(content, 4);
-    expect(result).toContain('  - [Parent](#parent)');
-    expect(result).toContain('    - [Child](#child)');
-    expect(result).toContain('      - [Grandchild](#grandchild)');
+    expect(result).toContain('- [Parent](#parent)');
+    expect(result).toContain('  - [Child](#child)');
+    expect(result).toContain('    - [Grandchild](#grandchild)');
   });
 
   it('inserts TOC after frontmatter', () => {
@@ -140,5 +141,113 @@ describe('generateToc', () => {
     const { content: result, entryCount } = generateToc(content);
     expect(entryCount).toBe(1);
     expect(result).toContain('- [Top Level](#top-level)');
+  });
+
+  // --- F1: frontmatter with literal '---' inside a block scalar ---
+
+  it('does not split frontmatter when YAML contains a literal --- block scalar', () => {
+    // The `description` block scalar contains a literal '---' line. A naive
+    // indexOf('---', n) would find this and insert the TOC mid-frontmatter.
+    const content = [
+      '---',
+      'title: Test',
+      'description: |',
+      '  ---',
+      '  divider in description',
+      '---',
+      '',
+      '## Real Heading',
+      '',
+    ].join('\n');
+
+    const { content: result } = generateToc(content);
+
+    // Frontmatter must remain intact and unmodified.
+    const fmStart = result.indexOf('---');
+    const fmEnd = result.indexOf('\n---\n', fmStart + 3);
+    expect(fmStart).toBe(0);
+    expect(fmEnd).toBeGreaterThan(0);
+
+    const frontmatter = result.slice(fmStart, fmEnd + 4);
+    expect(frontmatter).toContain('description: |');
+    expect(frontmatter).toContain('  ---');
+    expect(frontmatter).toContain('  divider in description');
+    // Description block scalar must NOT contain the TOC heading.
+    expect(frontmatter).not.toContain('Table of Contents');
+
+    // TOC should appear after the closing fence.
+    const tocStart = result.indexOf('## Table of Contents');
+    expect(tocStart).toBeGreaterThan(fmEnd);
+    expect(result).toContain('- [Real Heading](#real-heading)');
+  });
+
+  // --- F2: tilde-fenced code blocks ---
+
+  it('skips headings inside tilde-fenced code blocks', () => {
+    const content = fm(
+      '\n## Real Heading\n\n~~~markdown\n# Hidden\n## Also Hidden\n~~~\n\n## Another Real\n',
+    );
+    const { content: result, entryCount } = generateToc(content);
+    expect(entryCount).toBe(2);
+    expect(result).toContain('- [Real Heading](#real-heading)');
+    expect(result).toContain('- [Another Real](#another-real)');
+    // "Hidden" headings should not appear in TOC entries — but they remain in
+    // the document body, so check just the TOC region.
+    const tocStart = result.indexOf('## Table of Contents');
+    const tocEnd = result.indexOf('\n---', tocStart);
+    const tocBlock = result.slice(tocStart, tocEnd);
+    expect(tocBlock).not.toContain('Hidden');
+  });
+
+  // --- F3: slugify strips inline markdown ---
+
+  it('strips inline link syntax when slugifying headings', () => {
+    const content = fm('\n## Threat Model [Overview](./tm.md)\n');
+    const { content: result } = generateToc(content);
+    // Slug should match Obsidian's plain-text anchor: lowercase, hyphenated.
+    expect(result).toContain('(#threat-model-overview)');
+    // Display text should be the rendered plain text, not the raw link syntax.
+    expect(result).toContain('- [Threat Model Overview]');
+    // The TOC region itself must not contain link syntax (the body still does).
+    const tocStart = result.indexOf('## Table of Contents');
+    const tocEnd = result.indexOf('\n---', tocStart);
+    const tocBlock = result.slice(tocStart, tocEnd);
+    expect(tocBlock).not.toContain('[Overview](./tm.md)');
+  });
+
+  it('strips inline code when slugifying headings', () => {
+    const content = fm('\n## Using `useEffect` Hook\n');
+    const { content: result } = generateToc(content);
+    expect(result).toContain('(#using-useeffect-hook)');
+    expect(result).toContain('- [Using useEffect Hook]');
+  });
+
+  it('strips wikilinks when slugifying headings', () => {
+    const content = fm('\n## See [[Other Note|the other note]] for more\n');
+    const { content: result } = generateToc(content);
+    expect(result).toContain('- [See the other note for more]');
+    expect(result).toContain('(#see-the-other-note-for-more)');
+  });
+
+  // --- F4: non-contiguous heading levels ---
+
+  it('does not over-indent when document starts at H3', () => {
+    // Old behavior: H3 → 4 spaces (assumed H1 was the root). New behavior:
+    // shallowest is H3 → no indent.
+    const content = fm('\n### First\n\n### Second\n');
+    const { content: result } = generateToc(content);
+    expect(result).toContain('- [First](#first)');
+    expect(result).toContain('- [Second](#second)');
+    // No 4-space-indented entries.
+    expect(result).not.toMatch(/\n {4}- \[First\]/);
+    expect(result).not.toMatch(/\n {4}- \[Second\]/);
+  });
+
+  it('indents relative to shallowest level when doc starts at H2', () => {
+    // Doc with H2 + H4 (no H3): minLevel=2, H2=depth 0, H4=depth 2.
+    const content = fm('\n## Section\n\n#### Detail\n');
+    const { content: result } = generateToc(content, 4);
+    expect(result).toContain('- [Section](#section)');
+    expect(result).toContain('    - [Detail](#detail)');
   });
 });

--- a/tests/toc-generator.test.ts
+++ b/tests/toc-generator.test.ts
@@ -250,4 +250,108 @@ describe('generateToc', () => {
     expect(result).toContain('- [Section](#section)');
     expect(result).toContain('    - [Detail](#detail)');
   });
+
+  // --- Round-2: marker-aware fence tracking (boolean → marker refactor) ---
+  // Old `inCodeBlock` boolean treated any ``` or ~~~ as toggle, so a tilde
+  // line embedded inside a backtick fence (illustrative markdown showing
+  // alternative fences) would close the outer block early and headings
+  // after it would erroneously land in the TOC.
+
+  it('does not close a backtick fence when a tilde line appears inside', () => {
+    const content = fm(
+      [
+        '',
+        '## Real Heading',
+        '',
+        '```markdown',
+        '~~~',
+        '## Hidden Inner',
+        '~~~',
+        '## Still Hidden',
+        '```',
+        '',
+        '## Tail Heading',
+        '',
+      ].join('\n'),
+    );
+    const { content: result, entryCount } = generateToc(content);
+    // Only the two real headings; the inner ones are inside the backtick fence
+    expect(entryCount).toBe(2);
+    const tocStart = result.indexOf('## Table of Contents');
+    const tocEnd = result.indexOf('\n---', tocStart);
+    const tocBlock = result.slice(tocStart, tocEnd);
+    expect(tocBlock).toContain('Real Heading');
+    expect(tocBlock).toContain('Tail Heading');
+    expect(tocBlock).not.toContain('Hidden Inner');
+    expect(tocBlock).not.toContain('Still Hidden');
+  });
+
+  it('does not close a tilde fence when a backtick line appears inside', () => {
+    const content = fm(
+      [
+        '',
+        '## Real Heading',
+        '',
+        '~~~markdown',
+        '```',
+        '## Hidden Inner',
+        '```',
+        '## Still Hidden',
+        '~~~',
+        '',
+        '## Tail Heading',
+        '',
+      ].join('\n'),
+    );
+    const { content: result, entryCount } = generateToc(content);
+    expect(entryCount).toBe(2);
+    const tocStart = result.indexOf('## Table of Contents');
+    const tocEnd = result.indexOf('\n---', tocStart);
+    const tocBlock = result.slice(tocStart, tocEnd);
+    expect(tocBlock).toContain('Real Heading');
+    expect(tocBlock).toContain('Tail Heading');
+    expect(tocBlock).not.toContain('Hidden Inner');
+    expect(tocBlock).not.toContain('Still Hidden');
+  });
+
+  it('treats a fence that never closes as swallowing all subsequent headings', () => {
+    // Defensive: if the document leaves a fence open, headings after it
+    // shouldn't escape into the TOC. Better to under-include than to leak
+    // code into the TOC.
+    const content = fm(
+      ['', '## Before', '', '```', '## Trapped', '## Also Trapped', ''].join(
+        '\n',
+      ),
+    );
+    const { entryCount } = generateToc(content);
+    expect(entryCount).toBe(1);
+  });
+
+  it('handles multiple back-to-back fences with no trailing content', () => {
+    const content = fm(
+      [
+        '',
+        '## A',
+        '',
+        '```',
+        '## hidden a',
+        '```',
+        '',
+        '~~~',
+        '## hidden b',
+        '~~~',
+        '',
+        '## B',
+        '',
+      ].join('\n'),
+    );
+    const { content: result, entryCount } = generateToc(content);
+    expect(entryCount).toBe(2);
+    const tocStart = result.indexOf('## Table of Contents');
+    const tocEnd = result.indexOf('\n---', tocStart);
+    const tocBlock = result.slice(tocStart, tocEnd);
+    expect(tocBlock).toContain('- [A]');
+    expect(tocBlock).toContain('- [B]');
+    expect(tocBlock).not.toContain('hidden');
+  });
 });

--- a/tests/word-lists.test.ts
+++ b/tests/word-lists.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { WordListMatcher, sanitizeListName } from '../src/prose-highlight/word-lists';
+import {
+  WordListMatcher,
+  buildUniqueClassSuffixes,
+  sanitizeListName,
+} from '../src/prose-highlight/word-lists';
 import type { CustomWordList } from '../src/types';
 
 function makeList(overrides: Partial<CustomWordList> = {}): CustomWordList {
@@ -152,5 +156,59 @@ describe('WordListMatcher', () => {
     const matches = matcher.match('their theme');
     // "the" should not match inside "their" or "theme"
     expect(matches.length).toBe(0);
+  });
+
+  // --- F6: collision-safe class names ---
+
+  it('gives colliding list names distinct CSS classes', () => {
+    // "My List" and "my-list" both sanitize to "my-list"; without dedup
+    // they would share a class and POSStyleManager would emit two color
+    // rules for the same selector, with only the last winning.
+    const matcher = new WordListMatcher();
+    matcher.compile([
+      makeList({ name: 'My List', words: ['alpha'], color: '#aaa' }),
+      makeList({ name: 'my-list', words: ['beta'], color: '#bbb' }),
+    ]);
+
+    const matches = matcher.match('alpha and beta');
+    expect(matches.length).toBe(2);
+    const classes = matches.map((m) => m.cssClass).sort();
+    expect(classes).toEqual(
+      ['yaae-list-my-list', 'yaae-list-my-list-2'].sort(),
+    );
+    // Classes must be distinct so each list gets its own color rule.
+    expect(new Set(classes).size).toBe(2);
+  });
+});
+
+describe('buildUniqueClassSuffixes', () => {
+  it('returns the sanitized names when there are no collisions', () => {
+    expect(buildUniqueClassSuffixes(['Cloud', 'Languages', 'Tools'])).toEqual([
+      'cloud',
+      'languages',
+      'tools',
+    ]);
+  });
+
+  it('appends a numeric suffix to collisions', () => {
+    expect(
+      buildUniqueClassSuffixes(['My List', 'my-list', 'MY LIST']),
+    ).toEqual(['my-list', 'my-list-2', 'my-list-3']);
+  });
+
+  it('returns empty string for names that sanitize to empty', () => {
+    expect(buildUniqueClassSuffixes(['', '!!!', 'real'])).toEqual([
+      '',
+      '',
+      'real',
+    ]);
+  });
+
+  it('skips collision counter past existing suffixed names', () => {
+    // If a user already named a list "my-list-2", a later "My List" should
+    // not collide with it. Resolving uses the next available counter.
+    expect(
+      buildUniqueClassSuffixes(['My List', 'my-list-2', 'my-list']),
+    ).toEqual(['my-list', 'my-list-2', 'my-list-3']);
   });
 });

--- a/tests/word-lists.test.ts
+++ b/tests/word-lists.test.ts
@@ -211,4 +211,67 @@ describe('buildUniqueClassSuffixes', () => {
       buildUniqueClassSuffixes(['My List', 'my-list-2', 'my-list']),
     ).toEqual(['my-list', 'my-list-2', 'my-list-3']);
   });
+
+  // --- Round-2 edge cases (per /polish branch review) ---
+
+  it('returns empty array for empty input', () => {
+    expect(buildUniqueClassSuffixes([])).toEqual([]);
+  });
+
+  it('preserves index order when all names sanitize to empty', () => {
+    // When every name collapses to '', no collisions are tracked but every
+    // slot stays present so caller's `suffixes[i]` mapping holds.
+    expect(buildUniqueClassSuffixes(['', '   ', '!!!', '###'])).toEqual([
+      '',
+      '',
+      '',
+      '',
+    ]);
+  });
+
+  it('treats leading/trailing whitespace in names as a collision', () => {
+    // sanitizeListName trims edge non-alnum runs, so '  Cloud  ' and 'Cloud'
+    // sanitize identically. Without dedup, both lists would share a class.
+    expect(
+      buildUniqueClassSuffixes(['  Cloud  ', 'Cloud']),
+    ).toEqual(['cloud', 'cloud-2']);
+  });
+
+  it('does not let an empty entry break collision counter for later names', () => {
+    // An empty slot in the middle must not consume a numeric suffix slot
+    // for downstream colliding names.
+    expect(
+      buildUniqueClassSuffixes(['Tools', '', 'TOOLS']),
+    ).toEqual(['tools', '', 'tools-2']);
+  });
+
+  it('keeps three-way mixed-casing collision deterministic', () => {
+    // First wins; later collisions get the next free numeric suffix in input
+    // order — important so the rendered settings list matches the CSS rule
+    // table.
+    const result = buildUniqueClassSuffixes([
+      'Acronyms',
+      'ACRONYMS',
+      'acronyms',
+      'AcRoNyMs',
+    ]);
+    expect(result).toEqual([
+      'acronyms',
+      'acronyms-2',
+      'acronyms-3',
+      'acronyms-4',
+    ]);
+    // All four classes must be unique so each list gets its own color rule.
+    expect(new Set(result).size).toBe(4);
+  });
+
+  it('handles a name that already ends in -2 and collides with base', () => {
+    // 'My List 2' sanitizes to 'my-list-2' (no special-cased counter
+    // semantics in sanitizeListName). When 'my-list' arrives later it
+    // takes the base, then 'My List' would normally claim 'my-list-2'
+    // but that's taken — so it gets 'my-list-3'.
+    expect(
+      buildUniqueClassSuffixes(['My List 2', 'my-list', 'My List']),
+    ).toEqual(['my-list-2', 'my-list', 'my-list-3']);
+  });
 });


### PR DESCRIPTION
## Summary

Three concerns prompted this branch:
1. **Style Settings duplicated** YAAE's own POS color pickers (added in f4c1e61) — confusing UX
2. **Editor colors were single-value** — POS highlights and focus dim failed contrast on dark themes
3. **`POSStyleManager` `<style>` injection fought theme CSS** — theme authors couldn't recolor without `!important`

The fix layers CSS variables (`--foo-light` / `--foo-dark` switched by `body.theme-dark`), drops the duplicate plugin pickers in favor of Style Settings + theme overrides, and adds optional dark-theme variants to custom classifications. Public variables documented in `docs/theming.md` for theme authors.

## After-the-refactor bug hunt

An 8-agent bug hunt over the whole plugin found **33 issues** (5 P0, 13 P1, 14 P2, 1 P3). 5 were regressions from this refactor. All 33 fixed across 5 fix-clusters dispatched to parallel worktree agents, then merged sequentially with manual conflict resolution in two files.

### P0 fixes (classification correctness / data integrity)
- `cssText +=` was stripping the inline `--yaae-banner-*` custom properties set via `setProperty` → invisible classification banner
- `export.pdf.theme` from frontmatter never reached `PageChromeManager` → wrong banner colors in PDF
- Raw `classification` / `status` values injected into class names (DOMException + class fragmentation)
- TOC corrupted frontmatter when YAML contained literal `---` in a block scalar
- Whitespace classification mismatch (`"  internal  "` rendered banner in PDF but suppressed it in reading view)

### P1 fixes (toggle dead, races, theming gaps)
- `validateOnSave` toggle was inert after startup
- `updatePageChromeFromActiveFile` and `generateTocForCurrentFile` had file-switch races
- POS migration re-fired every plugin reload, fighting Style Settings
- `@media print and (prefers-color-scheme: dark)` doesn't fire in Chromium print — refactored to nest
- Auto-theme silently skipped when custom classification had no dark overrides
- Dark color picker silently wrote `colorDark` on first interaction, breaking inheritance
- `default: '#'` made dimmed text invisible
- `PageChromeManager` / `DynamicPdfPrintStyleManager` leaked orphan `<style>` on double-init
- Initial open of Obsidian directly into a classified file used `defaultClassification` for chrome
- Active-leaf-change to non-MD leaf cleared banner state
- Blank-ID custom classification appeared in Default dropdown
- Whitespace-only ID sanitized to `---` and slipped past validation
- `sanitizeColor` silent fallback could disguise classification (RESTRICTED renders as PUBLIC)

### P2 fixes (lifecycle, hygiene, performance)
Type-guard violations, shallow-merge crash on null `customClassifications`, non-string `cssclasses` filter crash, settings-tab nav listener leak, `editorCheckCallback` flag honored, per-keystroke save of partial classification entries, font dropdown silently overwriting arbitrary value, watermark layer overlap, reading-view regex compilation cached, word-list class collisions deduplicated with numeric suffixes, `buildSpans` per-character overlap detection, TOC tilde-fence parsing, `slugify` strips link/inline-code syntax, indent uses `level - minLevel`.

### P3
`saveSettings` mid-load — narrow window, deferred via `queueMicrotask`.

## Test count
- Before refactor: 377
- After refactor (theming): 379
- After all 5 fix-cluster merges: **474** (+95 new tests)
- All passing; build clean

## Files
36 files changed across `src/`, `tests/`, `styles.css`, plus new `docs/theming.md` and `src/document/settings-tab-helpers.ts`.

## Test plan
- [ ] Manual: light theme, POS highlights still iA-Writer palette
- [ ] Manual: dark theme, POS highlights brighter (legible on dark bg)
- [ ] Manual: theme override via `body.theme-dark { --yaae-pos-noun-color-dark: #ff00ff; }` in CSS snippet — should win without `!important`
- [ ] Manual: custom classification with light + dark color/bg pairs renders correctly per theme
- [ ] Manual: PDF export in dark + auto theme — banner colors switch (verify in dark-mode OS for `auto`)
- [ ] Manual: classification banner survives reading view re-render (no missing colors)
- [ ] Manual: with Style Settings installed, all `--yaae-pos-*-color-{light,dark}` knobs visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theming guide with CSS custom-property tunables (light/dark), PDF banner dark-mode support, and a custom PDF font option.

* **Improvements**
  * POS colors moved to themeable variables; safer/sanitized classification and word-list identifiers; more robust TOC generation; faster, cache-aware reading-view highlighting; improved print-theme (light/dark/auto) behavior; safer settings migration and UI event handling.

* **Bug Fixes**
  * Race-safety hardening, stricter color validation with warnings, and style injection idempotency.

* **Tests**
  * Expanded coverage across theming, print styles, highlights, TOC, settings, and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->