### PR TITLE
fix(prose-highlight): rebuild decorations on parse progress so code blocks stay clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.3",
   "devDependencies": {
+    "@codemirror/lang-markdown": "^6.0.0",
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.19.7",
     "@vitest/coverage-v8": "^4.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,15 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@codemirror/lang-markdown':
+        specifier: ^6.0.0
+        version: 6.5.0
+      '@codemirror/language':
+        specifier: ^6.0.0
+        version: 6.12.3
+      '@codemirror/state':
+        specifier: ^6.0.0
+        version: 6.5.0
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -50,7 +59,7 @@ importers:
         version: 11.7.5
       obsidian:
         specifier: ^1.7.2
-        version: 1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+        version: 1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.43.0)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -62,7 +71,7 @@ importers:
         version: 2.4.0
       wdio-obsidian-service:
         specifier: ^2.4.0
-        version: 2.4.0(obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(webdriverio@9.27.0)
+        version: 2.4.0(obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.43.0))(webdriverio@9.27.0)
 
   packages/print-styles: {}
 
@@ -98,11 +107,38 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
   '@codemirror/state@6.5.0':
     resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
 
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
   '@codemirror/view@6.38.6':
     resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@electron/get@4.0.2':
     resolution: {integrity: sha512-n9fRt/nzzOOZdDtTP3kT6GVdo0ro9FgMKCoS520kQMIiKBhpGmPny6yK/lER3tOCKr+wLYW1O25D9oI6ZinwCA==}
@@ -442,6 +478,27 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.4':
+    resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -2679,13 +2736,86 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.5.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
   '@codemirror/state@6.5.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/view@6.38.6':
     dependencies:
       '@codemirror/state': 6.5.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -2957,6 +3087,39 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@keyv/serialize@1.1.1': {}
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -4573,10 +4736,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
+  obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.43.0):
     dependencies:
       '@codemirror/state': 6.5.0
-      '@codemirror/view': 6.38.6
+      '@codemirror/view': 6.43.0
       '@types/codemirror': 5.60.8
       moment: 2.29.4
 
@@ -5176,10 +5339,10 @@ snapshots:
       '@wdio/reporter': 9.27.0
       '@wdio/spec-reporter': 9.27.0
 
-  wdio-obsidian-service@2.4.0(obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(webdriverio@9.27.0):
+  wdio-obsidian-service@2.4.0(obsidian@1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.43.0))(webdriverio@9.27.0):
     dependencies:
       lodash: 4.17.23
-      obsidian: 1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+      obsidian: 1.12.0(@codemirror/state@6.5.0)(@codemirror/view@6.43.0)
       obsidian-launcher: 2.4.0
       semver: 7.7.4
       tar: 7.5.13

--- a/src/prose-highlight/highlighter-plugin.ts
+++ b/src/prose-highlight/highlighter-plugin.ts
@@ -53,6 +53,26 @@ const EXCLUDED_PARENT_TYPES = new Set([
   'CommentBlock',
 ]);
 
+/**
+ * Case-insensitive substrings that mark a node family as non-prose. Catches
+ * HyperMD/Lezer naming variants (casing, `hmd-*` forms) that the exact-match
+ * Set above does not enumerate — e.g. `formatting-code`, `hmd-codeblock`,
+ * `CodeText` all contain `code`. Kept to code/frontmatter/comment families so
+ * structural nodes (`Document`, `Paragraph`, …) are never swept in.
+ */
+const EXCLUDED_NAME_SUBSTRINGS = ['code', 'frontmatter', 'comment'];
+
+/**
+ * Whether a syntax-tree node name marks content that must not be tagged.
+ * Exact-match against the enumerated set, then a substring allowlist so
+ * unenumerated code/frontmatter/comment variants are still excluded.
+ */
+export function isExcludedNodeType(name: string): boolean {
+  if (EXCLUDED_NODE_TYPES.has(name)) return true;
+  const lower = name.toLowerCase();
+  return EXCLUDED_NAME_SUBSTRINGS.some((s) => lower.includes(s));
+}
+
 interface LineTags {
   posTags: POSTag[];
   listMatches: WordListMatch[];
@@ -62,7 +82,7 @@ interface LineTags {
  * Collect ranges within the visible viewport that should be excluded
  * from NLP processing (code blocks, frontmatter, inline code, etc.)
  */
-function getExcludedRanges(
+export function getExcludedRanges(
   view: EditorView,
   from: number,
   to: number,
@@ -78,7 +98,7 @@ function getExcludedRanges(
         excluded.push({ from: node.from, to: node.to });
         return false; // don't descend
       }
-      if (EXCLUDED_NODE_TYPES.has(node.type.name)) {
+      if (isExcludedNodeType(node.type.name)) {
         excluded.push({ from: node.from, to: node.to });
       }
     },
@@ -88,7 +108,7 @@ function getExcludedRanges(
 }
 
 /** Merge overlapping/adjacent ranges */
-function mergeRanges(
+export function mergeRanges(
   ranges: Array<{ from: number; to: number }>,
 ): Array<{ from: number; to: number }> {
   if (ranges.length === 0) return [];
@@ -106,7 +126,7 @@ function mergeRanges(
 }
 
 /** Check if a position falls within any excluded range */
-function isExcluded(
+export function isExcluded(
   pos: number,
   excluded: Array<{ from: number; to: number }>,
 ): boolean {
@@ -192,6 +212,16 @@ export function createHighlighterExtension(plugin: YaaePlugin) {
           }
         }
         // Bulk change or line count changed — full rebuild
+        this.cache.clear();
+        this.decorations = this.buildDecorations(update.view);
+      } else if (syntaxTree(update.startState) !== syntaxTree(update.state)) {
+        // Markdown parses asynchronously: on first paint the code-block region
+        // is often unparsed, so getExcludedRanges() returned nothing and code
+        // words were tagged and cached. The cache holds tags computed before
+        // exclusion was known — invalidate it and rebuild on parse progress.
+        // Checked BEFORE viewportChanged: a scroll that coincides with the
+        // final parse step (both true in one update) must still clear the
+        // cache, and a full rebuild handles the new viewport implicitly.
         this.cache.clear();
         this.decorations = this.buildDecorations(update.view);
       } else if (update.viewportChanged) {

--- a/tests/highlighter-exclusion.test.ts
+++ b/tests/highlighter-exclusion.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { ensureSyntaxTree } from '@codemirror/language';
+import { markdown } from '@codemirror/lang-markdown';
+import type { EditorView } from '@codemirror/view';
+import {
+  getExcludedRanges,
+  mergeRanges,
+  isExcluded,
+  isExcludedNodeType,
+} from '../src/prose-highlight/highlighter-plugin';
+
+/**
+ * A markdown document mixing prose, a fenced code block, and inline code.
+ * Source-mode (Lezer) node names are reproducible here; HyperMD Live-Preview
+ * names are Obsidian-internal and cannot be tested outside Obsidian.
+ */
+const DOC = [
+  'This is beautiful prose with adjectives.', // line 1 — prose
+  '',
+  '```js',
+  'const beautiful = 42;',
+  'function quickly() {}',
+  '```',
+  '',
+  'More prose with `inline code` words here.', // last line — inline code
+].join('\n');
+
+/**
+ * getExcludedRanges only reads `view.state`, so a bare `{ state }` stub stands
+ * in for a real (DOM-bound) EditorView in this headless test.
+ */
+function stateView(doc: string): EditorView {
+  const state = EditorState.create({ doc, extensions: [markdown()] });
+  // Force a complete parse so syntaxTree() inside getExcludedRanges is whole.
+  // Fail loudly on an incomplete parse rather than silently asserting against
+  // a partial tree (a slow CI host or a larger doc could otherwise hide a bug).
+  if (!ensureSyntaxTree(state, doc.length, 5000)) {
+    throw new Error('markdown parse did not complete within the test budget');
+  }
+  return { state } as unknown as EditorView;
+}
+
+describe('getExcludedRanges (real Lezer markdown tree)', () => {
+  const view = stateView(DOC);
+  const excluded = getExcludedRanges(view, 0, DOC.length);
+
+  it('covers the full fenced-code block', () => {
+    const fenceOpen = DOC.indexOf('```js');
+    const fenceClose = DOC.lastIndexOf('```') + 3;
+    // Every offset across the fenced block must be excluded.
+    for (const probe of [
+      fenceOpen,
+      DOC.indexOf('const beautiful'),
+      DOC.indexOf('function quickly'),
+      fenceClose - 1,
+    ]) {
+      expect(isExcluded(probe, excluded)).toBe(true);
+    }
+  });
+
+  it('covers the inline-code span', () => {
+    expect(isExcluded(DOC.indexOf('inline code'), excluded)).toBe(true);
+  });
+
+  it('rejects a tag position inside code', () => {
+    // "beautiful" / "quickly" inside the fence must be rejected.
+    expect(isExcluded(DOC.indexOf('beautiful = 42'), excluded)).toBe(true);
+  });
+
+  it('keeps a prose position outside code', () => {
+    // "beautiful" in the first prose line is NOT excluded.
+    expect(isExcluded(DOC.indexOf('beautiful prose'), excluded)).toBe(false);
+    expect(isExcluded(DOC.indexOf('adjectives'), excluded)).toBe(false);
+  });
+});
+
+describe('isExcludedNodeType predicate', () => {
+  it('excludes code/frontmatter/comment node families', () => {
+    for (const name of [
+      'FencedCode',
+      'InlineCode',
+      'hmd-codeblock',
+      'CodeText',
+      'formatting-code',
+      'YAMLFrontMatter',
+      'hmd-frontmatter',
+      'CommentBlock',
+    ]) {
+      expect(isExcludedNodeType(name)).toBe(true);
+    }
+  });
+
+  it('keeps structural prose nodes', () => {
+    for (const name of [
+      'Document',
+      'Paragraph',
+      'Emphasis',
+      'StrongEmphasis',
+      'Heading',
+    ]) {
+      expect(isExcludedNodeType(name)).toBe(false);
+    }
+  });
+});
+
+describe('mergeRanges', () => {
+  it('merges overlapping and adjacent ranges, keeps disjoint', () => {
+    expect(
+      mergeRanges([
+        { from: 0, to: 5 },
+        { from: 3, to: 8 },
+        { from: 8, to: 10 },
+        { from: 15, to: 20 },
+      ]),
+    ).toEqual([
+      { from: 0, to: 10 },
+      { from: 15, to: 20 },
+    ]);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(mergeRanges([])).toEqual([]);
+  });
+});
+
+describe('isExcluded', () => {
+  const ranges = [{ from: 10, to: 20 }];
+
+  it('is inclusive of from, exclusive of to', () => {
+    expect(isExcluded(10, ranges)).toBe(true);
+    expect(isExcluded(19, ranges)).toBe(true);
+    expect(isExcluded(20, ranges)).toBe(false);
+  });
+
+  it('rejects positions outside every range', () => {
+    expect(isExcluded(5, ranges)).toBe(false);
+    expect(isExcluded(25, ranges)).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,9 @@ import { vi } from 'vitest';
 
 // Mock document for DOM operations
 const mockDocument = {
+  // @codemirror/view reads `document.documentElement.style` at module load for
+  // browser feature detection; an incomplete mock throws before any test runs.
+  documentElement: { style: {} },
   createElement: vi.fn((tag: string) => ({
     style: {
       cssText: '',


### PR DESCRIPTION
## Summary

Prose POS highlighting leaked into fenced and inline code on **first paint**, in both Live Preview and Source mode. Obsidian parses markdown asynchronously, so on file open `syntaxTree()` frequently hasn't yet parsed the code-block region — `getExcludedRanges()` returns `[]`, code words get tagged and cached, and the later parse-completion `ViewUpdate` (neither `docChanged` nor `viewportChanged`) was dropped, freezing the stale highlighted decorations until an edit or scroll happened to trigger a rebuild.

The fix makes `ProseHighlighter.update()` react to **parse progress**: on a `syntaxTree` change it clears the cache (the cached tags were computed before exclusion was known) and rebuilds. This branch is checked **before** `viewportChanged` so a scroll coinciding with the final parse step still clears the cache — a finding both review passes flagged.

Also hardens the exclusion predicate (`isExcludedNodeType`): exact-match set **plus** a case-insensitive substring allowlist (`code`/`frontmatter`/`comment`) so unenumerated HyperMD/Lezer name variants (`hmd-codeblock`, `formatting-code`, `CodeText`) can't slip a code word past the filter, without sweeping in structural nodes.

## Test plan

- `pnpm test` → **505 passed** (495 baseline + 10 new), 20 files.
- `pnpm run build` → exit 0; `@codemirror/*` stay externalized (test-only devDeps, not bundled).
- New `tests/highlighter-exclusion.test.ts` drives a **real Lezer markdown tree**: asserts fenced-block + inline-code spans are excluded, code positions rejected, prose kept; plus unit coverage of `isExcludedNodeType` / `mergeRanges` / `isExcluded`.
- **Manual (needs a human):** open `test-vault/Prose Highlighting Test.md` with prose highlighting on; confirm `const beautiful = …` / `function quickly()` in the ``` block and any `inline code` show **no** POS colors on first open (no scroll/edit), in both Live Preview and Source mode; close/reopen to re-check the cold-parse path.

## Drafts & follow-ups

No drafts.

Follow-ups (advisory — non-blocking review Nits + flagged scope):
- **esbuild `external`:** `@codemirror/lang-markdown` isn't in the `external` list. Dev-only today (zero bundle effect); adding it would be insurance if production source ever imports it.
- **Descent micro-opt:** `EXCLUDED_PARENT_TYPES` uses exact-match, so HyperMD variants matched only by the new substring check (e.g. `hmd-codeblock`) don't short-circuit descent. No correctness impact — children are subranges merged by `mergeRanges()` — just redundant traversal.
- **Out of scope:** syntax-*dimming* CSS may still leak into code fences — a separate feature/fix.
- Reading view (`reading-view.ts`) was not reported broken and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect syntax highlighting in code blocks during asynchronous Markdown parsing by improving cache invalidation.

* **Tests**
  * Added comprehensive test coverage for syntax node exclusion logic across various code and prose elements.

* **Chores**
  * Updated development dependencies to support enhanced markdown syntax handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->