### PR TITLE
fix(prose-highlight): disable on mobile pending root-cause fix (#32)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginSettingTab, App, Setting, MarkdownView, Notice, TFile } from 'obsidian';
+import { Plugin, PluginSettingTab, App, Setting, MarkdownView, Notice, TFile, Platform } from 'obsidian';
 import { Compartment } from '@codemirror/state';
 import type { Extension } from '@codemirror/state';
 import { YaaeSettings, DEFAULT_SETTINGS, FocusMode } from './src/types';
@@ -72,17 +72,24 @@ export default class YaaePlugin extends Plugin {
       this.settings.proseHighlight.customWordLists,
     );
 
-    // CM6 ViewPlugin for editor / Live Preview highlighting
+    // CM6 ViewPlugin for editor / Live Preview highlighting.
+    // Prose highlighting is disabled on mobile pending #32 — it errors / fails
+    // to render there. Gate both the editor extension and the Reading View
+    // post-processor so the feature is fully off on mobile; desktop is
+    // unaffected. registerEditorExtension still runs so the mutable extensions
+    // array stays wired for desktop toggling.
     const highlighterExt = createHighlighterExtension(this);
-    if (this.settings.proseHighlight.enabled) {
+    if (this.settings.proseHighlight.enabled && !Platform.isMobile) {
       this.editorExtensions.push(highlighterExt);
     }
     this.registerEditorExtension(this.editorExtensions);
 
     // Reading View post-processor
-    this.registerMarkdownPostProcessor(
-      createReadingViewPostProcessor(this),
-    );
+    if (!Platform.isMobile) {
+      this.registerMarkdownPostProcessor(
+        createReadingViewPostProcessor(this),
+      );
+    }
 
     // --- Readability Features ---
 
@@ -107,6 +114,10 @@ export default class YaaePlugin extends Plugin {
       id: 'toggle-prose-highlighting',
       name: 'Toggle prose highlighting',
       callback: () => {
+        if (Platform.isMobile) {
+          new Notice("Prose highlighting isn't available on mobile yet.");
+          return;
+        }
         this.settings.proseHighlight.enabled =
           !this.settings.proseHighlight.enabled;
         this.saveSettings();
@@ -312,11 +323,11 @@ export default class YaaePlugin extends Plugin {
 
   // --- Prose Highlight Methods ---
 
-  /** Enable or disable the CM6 editor extension */
+  /** Enable or disable the CM6 editor extension. No-op on mobile (#32). */
   toggleHighlighting(enabled: boolean): void {
     const highlighterExt = createHighlighterExtension(this);
     this.editorExtensions.length = 0;
-    if (enabled) {
+    if (enabled && !Platform.isMobile) {
       this.editorExtensions.push(highlighterExt);
     }
     this.app.workspace.updateOptions();


### PR DESCRIPTION
## Summary

Prose highlighting (POS colors) errors / fails to render on Obsidian **mobile**. Until the root cause is found (#32), this gates the feature off on mobile via `Platform.isMobile` at every entry point, so the rest of the plugin is unaffected. **Desktop behavior is unchanged.**

Guards added in `main.ts`:
- **onload:** skip the CM6 editor extension push *and* the Reading View post-processor registration on mobile (the two independent render paths).
- **`toggle-prose-highlighting` command:** show a Notice and no-op on mobile.
- **`toggleHighlighting()`:** never push the extension on mobile — covers `refreshHighlighting()` and any settings-driven re-enable path.

This is a **stop-gap, not the fix** — #32 tracks root-causing the actual mobile failure (needs the runtime error from a mobile dev console). Re-enable by removing the four guards once #32 lands.

## Test plan

- `pnpm test` → 495 passed.
- `pnpm run build` → exit 0.
- Static: no behavior change on desktop (`Platform.isMobile` is false there); mobile skips registration so no decorations/post-processor run.
- **Manual (needs devices):** on desktop confirm prose highlighting still works (editor + reading view, toggle command, settings); on mobile confirm no highlighting renders, the rest of YAAE works, and the toggle command shows the Notice.

## Drafts & follow-ups

No drafts.

Follow-ups:
- **#32** — root-cause prose highlighting on mobile (this PR only disables it). Also consider hiding the prose-highlight **settings UI** on mobile while disabled, so the controls aren't dead.
- **#33** — guttered headings render on mobile but the gutter takes a huge left margin (`--yaae-gutter-width: 4.5rem` is desktop-sized); needs a responsive width or a mobile disable. Filed separately; **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
